### PR TITLE
Feat/카카오 로그인 및 리프레시 토큰 구현 (7.10. 수정)

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/controller/AuthController.java
@@ -60,7 +60,13 @@ public class AuthController {
                 return ResponseEntity.status(401).body("Invalid refresh token");
             }
             // accessToken 재발급
-            String newAccessToken = jwtUtil.createJwt(username, user.getRole(), 60*60*60L); // 기존과 동일한 만료시간
+            String newAccessToken = jwtUtil.createJwt(
+                user.getId(),
+                user.getUsername(),
+                user.getName(),
+                user.getRole(),
+                60*60*60L
+            ); // 기존과 동일한 만료시간
             return ResponseEntity.ok().body(newAccessToken);
         } catch (Exception e) {
             return ResponseEntity.status(401).body("Invalid refresh token");

--- a/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTFilter.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTFilter.java
@@ -19,64 +19,110 @@ public class JWTFilter extends OncePerRequestFilter {
     private final JWTUtil jwtUtil;
 
     public JWTFilter(JWTUtil jwtUtil) {
-
         this.jwtUtil = jwtUtil;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+        System.out.println("JWTFilter: Request URI = " + path); // 요청 URI 로그 추가
 
-        //cookie들을 불러온 뒤 Authorization Key에 담긴 쿠키를 찾음
+        // /login, /oauth2 경로는 필터를 건너뜀
+        if (path.startsWith("/login") || path.startsWith("/oauth2")) {
+            System.out.println("JWTFilter: Skipping filter for path: " + path);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String authorization = null;
         Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
 
-            System.out.println(cookie.getName());
-            if (cookie.getName().equals("Authorization")) {
-
-                authorization = cookie.getValue();
+        // 쿠키에서 Authorization 토큰 찾기
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                // System.out.println("JWTFilter: Cookie found - " + cookie.getName()); // 모든 쿠키 이름 로깅 (필요 시 주석 해제)
+                if (cookie.getName().equals("Authorization")) {
+                    authorization = cookie.getValue();
+                    System.out.println("JWTFilter: Authorization cookie found.");
+                    break; // 찾았으면 더 이상 반복할 필요 없음
+                }
             }
         }
 
-        //Authorization 헤더 검증
+        // 쿠키에 없으면 Authorization 헤더에서 찾기
         if (authorization == null) {
+            String headerAuth = request.getHeader("Authorization");
+            if (headerAuth != null && headerAuth.startsWith("Bearer ")) {
+                authorization = headerAuth.substring(7);
+                System.out.println("JWTFilter: Authorization header (Bearer) found.");
+            }
+        }
 
-            System.out.println("token null");
+        // Authorization 토큰이 없는 경우
+        if (authorization == null) {
+            System.out.println("JWTFilter: Token not found in cookies or Authorization header. Proceeding without authentication.");
             filterChain.doFilter(request, response);
-
-            //조건이 해당되면 메소드 종료 (필수)
             return;
         }
 
-        //토큰
         String token = authorization;
+        System.out.println("JWTFilter: Token received (first few chars): " + token.substring(0, Math.min(token.length(), 20)) + "..."); // 토큰 일부 로깅
 
-        //토큰 소멸 시간 검증
-        if (jwtUtil.isExpired(token)) {
+        try {
+            // 토큰 소멸 시간 검증
+            if (jwtUtil.isExpired(token)) {
+                System.out.println("JWTFilter: Token is EXPIRED.");
+                // 토큰이 만료되었지만, 스프링 시큐리티의 다른 필터에서 401 Unauthorized를 처리할 수 있도록 filterChain을 계속 진행
+                filterChain.doFilter(request, response);
+                return;
+            }
 
-            System.out.println("token expired");
+            // 토큰에서 정보 획득
+            String username = jwtUtil.getUsername(token);
+            String role = jwtUtil.getRole(token);
+            Long id = null;
+            String name = null;
+
+            try {
+                id = jwtUtil.getId(token);
+            } catch (Exception e) {
+                System.out.println("JWTFilter: Could not get ID from token (might be for refresh token or specific payload format): " + e.getMessage());
+            }
+            try {
+                name = jwtUtil.getName(token);
+            } catch (Exception e) {
+                System.out.println("JWTFilter: Could not get Name from token (might be for refresh token or specific payload format): " + e.getMessage());
+            }
+
+            System.out.println("JWTFilter: Token Payload - Username: " + username + ", Role: " + role + ", ID: " + id + ", Name: " + name);
+
+            // UserDTO 생성 및 값 설정
+            UserDTO userDTO = new UserDTO();
+            userDTO.setId(id);
+            userDTO.setUsername(username);
+            userDTO.setRole(role);
+            userDTO.setName(name);
+
+            // UserDetails에 회원 정보 객체 담기
+            CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO);
+
+            // 스프링 시큐리티 인증 토큰 생성
+            Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+            // 세션에 사용자 등록 (SecurityContextHolder에 Authentication 객체 설정)
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+            System.out.println("JWTFilter: Authentication successful for user: " + username);
+
+        } catch (io.jsonwebtoken.security.SignatureException e) {
+            System.out.println("JWTFilter: Token parsing failed - Invalid Signature: " + e.getMessage());
+            // 서명 검증 실패 시, 이후 필터에서 401 처리될 수 있도록 진행
             filterChain.doFilter(request, response);
-
-            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        } catch (Exception e) {
+            System.out.println("JWTFilter: Token parsing failed - General Error: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+            // 기타 토큰 파싱 실패 시, 이후 필터에서 401 처리될 수 있도록 진행
+            filterChain.doFilter(request, response);
             return;
         }
-
-        //토큰에서 username과 role 획득
-        String username = jwtUtil.getUsername(token);
-        String role = jwtUtil.getRole(token);
-
-        //userDTO를 생성하여 값 set
-        UserDTO userDTO = new UserDTO();
-        userDTO.setUsername(username);
-        userDTO.setRole(role);
-
-        //UserDetails에 회원 정보 객체 담기
-        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO);
-
-        //스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
-        //세션에 사용자 등록
-        SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTUtil.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTUtil.java
@@ -1,6 +1,7 @@
 package com.umc.tomorrow.domain.auth.jwt;
 
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -16,9 +17,8 @@ public class JWTUtil {
     private SecretKey secretKey;
 
     public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
-
-
-        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        // secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String getUsername(String token) {
@@ -36,10 +36,11 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String username, String role, Long expiredMs) {
-
+    public String createJwt(Long id, String username, String name, String role, Long expiredMs) {
         return Jwts.builder()
+                .claim("id", id)
                 .claim("username", username)
+                .claim("name", name)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
@@ -55,5 +56,13 @@ public class JWTUtil {
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    public Long getId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
+    }
+
+    public String getName(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/auth/security/CustomOAuth2User.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/security/CustomOAuth2User.java
@@ -6,6 +6,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 public class CustomOAuth2User implements OAuth2User {
@@ -19,8 +20,7 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public Map<String, Object> getAttributes() {
-
-        return null;
+        return Collections.emptyMap();
     }
 
     @Override
@@ -49,5 +49,9 @@ public class CustomOAuth2User implements OAuth2User {
     public String getUsername() {
 
         return userDTO.getUsername();
+    }
+
+    public UserDTO getUserDTO() {
+        return userDTO;
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/controller/MemberController.java
@@ -1,0 +1,53 @@
+/**
+ * 회원 관련 API 컨트롤러
+ * - GET /api/v1/members/me : 내 정보 조회
+ * - PUT /api/v1/members/me : 내 정보 수정
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-10
+ */
+package com.umc.tomorrow.domain.member.controller;
+
+import com.umc.tomorrow.domain.member.dto.UserDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
+import com.umc.tomorrow.domain.member.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag(name = "member-controller", description = "회원 관련 API")
+@RestController
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 회원의 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<UserDTO> getMe(@AuthenticationPrincipal CustomOAuth2User user) {
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+        UserDTO userDTO = user.getUserDTO();
+        return ResponseEntity.ok(userDTO);
+    }
+
+    /**
+     * 내 정보 수정
+     * 실제로 DB에 회원 정보가 반영되도록 MemberService를 호출
+     */
+    @Operation(summary = "내 정보 수정", description = "현재 로그인한 회원의 정보를 수정합니다.")
+    @PutMapping("/me")
+    public ResponseEntity<UserDTO> updateMe(@AuthenticationPrincipal CustomOAuth2User user, @RequestBody UserDTO userDTO) {
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+        // 실제 DB에 회원 정보 업데이트
+        UserDTO updated = memberService.updateUser(user.getUserDTO(), userDTO);
+        return ResponseEntity.ok(updated);
+    }
+} 

--- a/src/main/java/com/umc/tomorrow/domain/member/dto/UserDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/dto/UserDTO.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Setter
 public class UserDTO {
 
+    private Long id;
     private String role;
     private String name;
     private String username;

--- a/src/main/java/com/umc/tomorrow/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/service/MemberService.java
@@ -1,0 +1,56 @@
+/**
+ * 회원 정보 서비스
+ * - 회원 정보 수정 등 비즈니스 로직 처리
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-10
+ */
+package com.umc.tomorrow.domain.member.service;
+
+import com.umc.tomorrow.domain.member.dto.UserDTO;
+import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.member.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public MemberService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 회원 정보 수정
+     * @param currentUser 현재 로그인한 회원의 DTO (id 포함)
+     * @param userDTO 수정할 정보가 담긴 DTO
+     * @return 수정된 회원 정보 DTO
+     */
+    @Transactional
+    public UserDTO updateUser(UserDTO currentUser, UserDTO userDTO) {
+        Long userId = currentUser.getId();
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+        user.setUsername(userDTO.getUsername());
+        user.setName(userDTO.getName());
+        user.setRole(userDTO.getRole());
+        user.setRefreshToken(userDTO.getRefreshToken());
+        // 변경된 엔티티를 저장 
+        return toDTO(user);
+    }
+
+    /**
+     * User 엔티티를 UserDTO로 변환
+     */
+    public UserDTO toDTO(User user) {
+        UserDTO dto = new UserDTO();
+        dto.setUsername(user.getUsername());
+        dto.setName(user.getName());
+        dto.setRole(user.getRole());
+        dto.setRefreshToken(user.getRefreshToken());
+        return dto;
+    }
+} 

--- a/src/main/java/com/umc/tomorrow/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/tomorrow/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
@@ -17,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 @Configuration
@@ -49,17 +51,18 @@ public class SecurityConfig {
                         CorsConfiguration configuration = new CorsConfiguration();
 
                         configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
-                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                         configuration.setAllowCredentials(true);
                         configuration.setAllowedHeaders(Collections.singletonList("*"));
                         configuration.setMaxAge(3600L);
-
-                        configuration.setExposedHeaders(Collections.singletonList("Set-Cookie"));
-                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+                        configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
 
                         return configuration;
                     }
                 }));
+
+        http.csrf(AbstractHttpConfigurer::disable); // 추가
+
         http
                 .formLogin((auth) -> auth.disable());
         http
@@ -82,7 +85,9 @@ public class SecurityConfig {
                 );
         http
                 .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/").permitAll() //경로별 인가작업
+                        .requestMatchers("/login").permitAll()
                         .anyRequest().authenticated());
         http
                 .sessionManagement((session) -> session

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,6 +86,7 @@ logging:
   level:
     com.umc.tomorrow: INFO
     root: INFO
+    # org.springframework.security: DEBUG #  logging을 위해
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
 


### PR DESCRIPTION
- 카카오 소셜 로그인 기능 추가
- JWT 리프레시 토큰 발급 및 갱신 로직 구현
- **문제 해결:** JWT "Invalid Signature" 오류 수정
  - `JWTUtil`에서 SecretKey 생성 방식을 `Keys.hmacShaKeyFor()`로 변경하여 토큰 서명 검증 오류 해결.
- **문제 해결:** PUT 요청 시 무한 리다이렉트 (CSRF 403 Forbidden) 오류 수정
  - `SecurityConfig`에서 CSRF 보호를 비활성화하여 API 호출 시 불필요한 CSRF 토큰 검증 제거.
- 관련 이슈: #10 (close #10)

## 관련 이슈
- close #이슈번호

## PR 유형
- [ ] 버그 수정
- [ ] 환경 설정

## 작업 내용
- `JWTUtil` 클래스 내 JWT SecretKey 생성 방식을 `Keys.hmacShaKeyFor()`로 변경하여 "Invalid Signature" 오류를 해결.
- `SecurityConfig` 클래스에서 CSRF 보호 기능을 비활성화하여 PUT 요청 시 발생하던 무한 리다이렉트 (403 Forbidden) 문제를 해결.
- Swagger UI 등 API 테스트 환경에서의 PUT 요청 확인함.

## 🖼스크린샷 (선택)
<img width="1255" height="943" alt="image" src="https://github.com/user-attachments/assets/d83cc725-52df-4892-877c-e6846854a7bb" />
<img width="1454" height="836" alt="image" src="https://github.com/user-attachments/assets/2c0604d2-a85b-445e-bae0-cd8f20123534" />

