### PR TITLE
feat: 일자리 폼 api구현

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/job/controller/JobCommandController.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/controller/JobCommandController.java
@@ -1,0 +1,30 @@
+package com.umc.tomorrow.domain.job.controller;
+
+import com.umc.tomorrow.domain.job.dto.request.CreateJobRequestDTO;
+import com.umc.tomorrow.domain.job.dto.response.JobStepResponseDTO;
+import com.umc.tomorrow.domain.job.service.command.JobCommandService;
+import com.umc.tomorrow.global.common.base.BaseResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/jobs")
+@RequiredArgsConstructor
+public class JobCommandController {
+
+    private final JobCommandService jobCommandService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<JobStepResponseDTO>> saveJobStepOne(
+            @Valid @RequestBody CreateJobRequestDTO requestDTO,
+            HttpSession session
+    ) {
+        JobStepResponseDTO result = jobCommandService.saveInitialJobStep(requestDTO, session);
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+
+    }
+
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
@@ -1,0 +1,65 @@
+package com.umc.tomorrow.domain.job.converter;
+
+import com.umc.tomorrow.domain.job.dto.request.CreateJobRequestDTO;
+import com.umc.tomorrow.domain.job.dto.request.WorkDaysRequestDTO;
+import com.umc.tomorrow.domain.job.dto.request.WorkEnvironmentRequestDTO;
+import com.umc.tomorrow.domain.job.entity.*;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobConverter {
+
+    public Job toJob(CreateJobRequestDTO dto) {
+        return Job.builder()
+                .title(dto.getTitle())
+                .jobCategory(dto.getJobCategory())
+                .workPeriod(dto.getWorkPeriod())
+                .isPeriodNegotiable(dto.getIsPeriodNegotiable())
+                .workStart(dto.getWorkStart())
+                .workEnd(dto.getWorkEnd())
+                .isTimeNegotiable(dto.getIsTimeNegotiable())
+                .paymentType(dto.getPaymentType())
+                .salary(dto.getSalary())
+                .jobDescription(dto.getJobDescription())
+                .jobImageUrl(dto.getJobImageUrl())
+                .companyName(dto.getCompanyName())
+                .isActive(dto.getIsActive())
+                .recruitmentLimit(dto.getRecruitmentLimit())
+                .registrantType(dto.getRegistrantType())
+                .deadline(dto.getDeadline())
+                .preferredQualifications(dto.getPreferredQualifications())
+                .latitude(dto.getLatitude())
+                .longitude(dto.getLongitude())
+                .location(dto.getLocation())
+                .alwaysHiring(dto.getAlwaysHiring())
+
+                .workDays(toWorkDays(dto.getWorkDays()))
+                .workEnvironment(toWorkEnvironment(dto.getWorkEnvironment()))
+                .build();
+    }
+
+    public WorkDays toWorkDays(WorkDaysRequestDTO dto) {
+        return WorkDays.builder()
+                .MON(dto.getMON())
+                .TUE(dto.getTUE())
+                .WED(dto.getWED())
+                .THU(dto.getTHU())
+                .FRI(dto.getFRI())
+                .SAT(dto.getSAT())
+                .SUN(dto.getSUN())
+                .isDayNegotiable(dto.getIsDayNegotiable())
+                .build();
+    }
+
+    public WorkEnvironment toWorkEnvironment(WorkEnvironmentRequestDTO dto) {
+        return WorkEnvironment.builder()
+                .canWorkSitting(dto.getCanWorkSitting())
+                .canWorkStanding(dto.getCanWorkStanding())
+                .canLiftHeavyObjects(dto.getCanLiftHeavyObjects())
+                .canLiftLightObjects(dto.getCanLiftLightObjects())
+                .canMoveActively(dto.getCanMoveActively())
+                .canCommunicate(dto.getCanCommunicate())
+                .build();
+    }
+}
+

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/JobSessionDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/JobSessionDTO.java
@@ -1,0 +1,16 @@
+package com.umc.tomorrow.domain.job.dto;
+
+import com.umc.tomorrow.domain.job.enums.RegistrantType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class JobSessionDTO {
+    private String title;
+    private String jobCategory;
+    private LocalDateTime deadline;
+    private RegistrantType registrantType;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/request/CreateJobRequestDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/request/CreateJobRequestDTO.java
@@ -1,0 +1,81 @@
+package com.umc.tomorrow.domain.job.dto.request;
+
+import com.umc.tomorrow.domain.job.enums.PaymentType;
+import com.umc.tomorrow.domain.job.enums.RegistrantType;
+import com.umc.tomorrow.domain.job.enums.WorkPeriod;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateJobRequestDTO {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "카테고리는 필수입니다.")
+    private String jobCategory;
+
+    @NotNull(message = "근무 기간은 필수입니다.")
+    private WorkPeriod workPeriod;
+
+    private Boolean isPeriodNegotiable = false;
+
+    private LocalDateTime workStart;
+    private LocalDateTime workEnd;
+
+    private Boolean isTimeNegotiable = false;
+
+    @NotNull(message = "급여 형태는 필수입니다.")
+    private PaymentType paymentType;
+
+    @NotNull(message = "급여는 필수입니다.")
+    @Min(value = 1, message = "급여는 1 이상이어야 합니다.")
+    private Integer salary;
+
+    private String jobDescription;
+    private String jobImageUrl;
+    private String companyName;
+
+    @NotNull(message = "공고 활성 여부는 필수입니다.")
+    private Boolean isActive;
+
+    @NotNull(message = "모집 인원은 필수입니다.")
+    @Min(value = 1, message = "모집 인원은 1 이상이어야 합니다.")
+    private Integer recruitmentLimit;
+
+    @NotNull(message = "등록자 유형은 필수입니다.")
+    private RegistrantType registrantType;
+
+    @NotNull(message = "마감일은 필수입니다.")
+    private LocalDateTime deadline;
+
+    private String preferredQualifications;
+
+    @NotNull(message = "위도는 필수입니다.")
+    private BigDecimal latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private  BigDecimal longitude;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String location;
+
+    private Boolean alwaysHiring = false;
+
+    //서브 테이블 DTO 포함
+    @Valid
+    @NotNull(message = "근무 요일 정보는 필수입니다.")
+    private WorkDaysRequestDTO workDays;
+
+    @Valid
+    @NotNull(message = "근무 환경 정보는 필수입니다.")
+    private WorkEnvironmentRequestDTO workEnvironment;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/request/WorkDaysRequestDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/request/WorkDaysRequestDTO.java
@@ -1,0 +1,36 @@
+package com.umc.tomorrow.domain.job.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkDaysRequestDTO {
+
+    @NotNull
+    private Boolean MON;
+
+    @NotNull
+    private Boolean TUE;
+
+    @NotNull
+    private Boolean WED;
+
+    @NotNull
+    private Boolean THU;
+
+    @NotNull
+    private Boolean FRI;
+
+    @NotNull
+    private Boolean SAT;
+
+    @NotNull
+    private Boolean SUN;
+
+    @NotNull(message = "요일 협의 가능 여부는 필수입니다.")
+    private Boolean isDayNegotiable;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/request/WorkEnvironmentRequestDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/request/WorkEnvironmentRequestDTO.java
@@ -1,0 +1,30 @@
+package com.umc.tomorrow.domain.job.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkEnvironmentRequestDTO {
+
+    @NotNull
+    private Boolean canWorkSitting;
+
+    @NotNull
+    private Boolean canWorkStanding;
+
+    @NotNull
+    private Boolean canLiftHeavyObjects;
+
+    @NotNull
+    private Boolean canLiftLightObjects;
+
+    @NotNull
+    private Boolean canMoveActively;
+
+    @NotNull
+    private Boolean canCommunicate;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/response/JobStepResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/response/JobStepResponseDTO.java
@@ -1,0 +1,12 @@
+package com.umc.tomorrow.domain.job.dto.response;
+
+import com.umc.tomorrow.domain.job.enums.RegistrantType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JobStepResponseDTO {
+    private RegistrantType registrantType;
+    private String step;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/BusinessVerification.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/BusinessVerification.java
@@ -1,0 +1,35 @@
+package com.umc.tomorrow.domain.job.entity;
+
+import com.umc.tomorrow.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BusinessVerification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String bizNumber;
+
+    @Column(nullable = false, length = 100)
+    private String companyName;
+
+    @Column(nullable = false, length = 50)
+    private String ownerName;
+
+    @Column(nullable = false)
+    private LocalDate openingDate;
+
+    //연관관계
+    @OneToOne(mappedBy = "businessVerification")
+    private Job job;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
@@ -1,0 +1,130 @@
+package com.umc.tomorrow.domain.job.entity;
+
+import com.umc.tomorrow.domain.job.enums.PaymentType;
+import com.umc.tomorrow.domain.job.enums.RegistrantType;
+import com.umc.tomorrow.domain.job.enums.WorkPeriod;
+import com.umc.tomorrow.domain.member.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "job",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_job_work_env", columnNames = "work_environment_id"),
+                @UniqueConstraint(name = "uk_job_personal_reg", columnNames = "personal_registration_id"),
+                @UniqueConstraint(name = "uk_job_work_days", columnNames = "work_days_id"),
+                @UniqueConstraint(name = "uk_job_business_verification", columnNames = "business_verification_id")
+        })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Job {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = false, length = 30)
+    private String jobCategory;
+
+    @Enumerated(EnumType.STRING)
+    private WorkPeriod workPeriod;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false", nullable = false) //false라면 workPeriod를 필수로 입력 받아야함
+    private Boolean isPeriodNegotiable;
+
+    private LocalDateTime workStart;
+
+    private LocalDateTime workEnd;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false") //false라면 workStart, workEnd를 필수로 입력 받아야함
+    private Boolean isTimeNegotiable;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    //private PaymentType paymentType;
+    private PaymentType paymentType = PaymentType.HOURLY; //테스트용
+
+    @Column(nullable = false)
+    private Integer salary;
+
+    @Lob
+    private String jobDescription;
+
+    private String jobImageUrl;
+
+    @Column(length = 100)
+    private String companyName;
+
+    @Column(nullable = false)
+    private Boolean isActive; //공고 활성화 여부
+
+    @Column(nullable = false)
+    private Integer recruitmentLimit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    //private RegistrantType registrantType;
+    private RegistrantType registrantType = RegistrantType.BUSINESS;//테스트용
+
+    @Column(nullable = false)
+    private LocalDateTime deadline;
+
+    @Lob
+    private String preferredQualifications;
+
+    @Column(precision = 10, scale = 7, nullable = false)//지도 api추가 후 nullable = false로 변경
+    private BigDecimal latitude; //위도
+
+    @Column(precision = 10, scale = 7, nullable = false)//지도 api추가 후 nullable = false로 변경
+    private BigDecimal longitude; //경도
+
+    @Column(length = 100)//지도 api추가 후 nullable = false로 변경
+    private String location;//위도, 경도를 받아서 address에 저장
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean alwaysHiring;
+
+    //businessVerification와 1:1관계
+    @OneToOne(cascade = CascadeType.ALL, optional = false)
+    @JoinColumn(name = "business_verification_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_job_business_verification"))
+    private BusinessVerification businessVerification;
+
+    //personalRegistration와 1:1관계
+    @OneToOne(cascade = CascadeType.ALL, optional = false)
+    @JoinColumn(name = "personal_registration_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_job_personal_registration"))
+    private PersonalRegistration personalRegistration;
+
+    //workDays와 1:1관계
+    @OneToOne(cascade = CascadeType.ALL, optional = false)
+    @JoinColumn(name = "work_days_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_job_work_days"))
+    //private WorkDays workDays;
+    private WorkDays workDays;
+
+    //WorkEnvironment와 1:1관계
+    @OneToOne(cascade = CascadeType.ALL, optional = false)
+    @JoinColumn(name = "work_environment_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_job_work_environment"))
+    private WorkEnvironment workEnvironment;
+
+    //user와 1:N와 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 등록자
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/PersonalRegistration.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/PersonalRegistration.java
@@ -1,0 +1,41 @@
+package com.umc.tomorrow.domain.job.entity;
+
+import com.umc.tomorrow.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PersonalRegistration extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(nullable = false, length = 20)
+    private String contact;
+
+    @Column(columnDefinition = "TEXT")
+    private String registrationPurpose;
+
+    @Column(nullable = false, length = 50)
+    private String address;
+
+    //연관관계
+    @OneToOne(mappedBy = "personalRegistration")
+    private Job job;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/WorkDays.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/WorkDays.java
@@ -1,0 +1,47 @@
+package com.umc.tomorrow.domain.job.entity;
+
+
+import com.umc.tomorrow.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class WorkDays extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean MON;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean TUE;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean WED;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean THU;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean FRI;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean SAT;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean SUN;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean isDayNegotiable;
+
+    //연관관계
+    @OneToOne(mappedBy = "workDays")
+    private Job job;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/WorkEnvironment.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/WorkEnvironment.java
@@ -1,0 +1,39 @@
+package com.umc.tomorrow.domain.job.entity;
+
+import com.umc.tomorrow.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class WorkEnvironment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean canWorkSitting;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean canWorkStanding;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean canLiftHeavyObjects;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean canLiftLightObjects;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean canMoveActively;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean canCommunicate;
+
+    //연관관계
+    @OneToOne(mappedBy = "workEnvironment")
+    private Job job;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/enums/PaymentType.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/enums/PaymentType.java
@@ -1,0 +1,8 @@
+package com.umc.tomorrow.domain.job.enums;
+
+public enum PaymentType {
+    HOURLY,     // 시급
+    PER_TASK,   // 건당
+    DAILY,      // 일급
+    MONTHLY     // 월급
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/enums/RegistrantType.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/enums/RegistrantType.java
@@ -1,0 +1,6 @@
+package com.umc.tomorrow.domain.job.enums;
+
+public enum RegistrantType {
+    PERSONAL,   // 개인
+    BUSINESS    // 사업자
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/enums/WorkPeriod.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/enums/WorkPeriod.java
@@ -1,0 +1,9 @@
+package com.umc.tomorrow.domain.job.enums;
+
+public enum WorkPeriod {
+    SHORT_TERM,
+    OVER_ONE_MONTH,
+    OVER_THREE_MONTH,
+    OVER_SIX_MONTH,
+    OVER_ONE_YEAR
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/repository/JobRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/repository/JobRepository.java
@@ -1,0 +1,10 @@
+package com.umc.tomorrow.domain.job.repository;
+
+import com.umc.tomorrow.domain.job.entity.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobRepository extends JpaRepository<Job, Long> {
+
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/service/command/JobCommandService.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/service/command/JobCommandService.java
@@ -1,0 +1,22 @@
+package com.umc.tomorrow.domain.job.service.command;
+
+import com.umc.tomorrow.domain.job.dto.request.CreateJobRequestDTO;
+import com.umc.tomorrow.domain.job.dto.response.JobStepResponseDTO;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JobCommandService {
+
+    private static final String JOB_SESSION_KEY = "job_session";
+
+    public JobStepResponseDTO saveInitialJobStep(CreateJobRequestDTO requestDTO, HttpSession session) {
+
+        session.setAttribute(JOB_SESSION_KEY, requestDTO);
+
+        return JobStepResponseDTO.builder()
+                .registrantType(requestDTO.getRegistrantType())
+                .step("job_form_saved")
+                .build();
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
@@ -1,11 +1,12 @@
 package com.umc.tomorrow.domain.member.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.umc.tomorrow.domain.job.entity.Job;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,4 +26,8 @@ public class User {
 
     // Refresh Token 저장
     private String refreshToken;
+
+    //연관관계
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Job> jobs = new ArrayList<>(); // 내가 등록한 일자리 목록
 }


### PR DESCRIPTION
## 관련 이슈
- close #13

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 구인을 위한 일자리 폼 /api/vi/jobs의 api를 구현했습니다.

## 리뷰 포인트

## 🖼스크린샷 (선택)
<img width="1350" height="440" alt="등록1" src="https://github.com/user-attachments/assets/32378fe9-23d5-4ce8-8dff-4e8d98e80f75" />
<img width="1118" height="382" alt="등록2" src="https://github.com/user-attachments/assets/38737727-f629-4864-bb88-94499fbc435c" />

