### PR TITLE
Feat/preferences#21

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTFilter.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTFilter.java
@@ -130,7 +130,3 @@ public class JWTFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 }
-
-public enum Gender {
-    MALE, FEMALE
-}

--- a/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTUtil.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/jwt/JWTUtil.java
@@ -36,14 +36,21 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(Long id, String name, Long expiredMs) {
+    public String createJwt(Long id, String name, String username, String role, Long expiredMs) {
         return Jwts.builder()
                 .claim("id", id)
                 .claim("name", name)
+                .claim("username", username)
+                .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    // 기존 시그니처도 남겨둠 (호환성)
+    public String createJwt(Long id, String name, Long expiredMs) {
+        return createJwt(id, name, null, null, expiredMs);
     }
 
     // Refresh Token 생성 (username만 claim, 만료시간은 더 길게)

--- a/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
@@ -47,11 +47,27 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             // 소셜 로그인 정보로 새 회원 생성
             user = new User();
             user.setName(customUserDetails.getName()); // 필요시
+            // 필수값 세팅
+            user.setCreatedAt(java.time.LocalDateTime.now());
+            user.setUpdatedAt(java.time.LocalDateTime.now());
+            // provider, providerUserId, username, email 세팅
+            String providerStr = customUserDetails.getUserDTO().getProvider();
+            String providerUserId = customUserDetails.getUserDTO().getProviderUserId();
+            if (providerStr != null) {
+                user.setProvider(User.Provider.valueOf(providerStr.toUpperCase()));
+            }
+            user.setProviderUserId(providerUserId);
+            // username은 provider + '_' + providerUserId로 생성
+            String usernameValue = (providerStr != null && providerUserId != null) ? providerStr + "_" + providerUserId : null;
+            user.setUsername(usernameValue);
+            user.setEmail(customUserDetails.getUserDTO().getEmail());
             userRepository.save(user);
         }
         String token = jwtUtil.createJwt(
             user.getId(),
             user.getName(),
+            user.getUsername(),
+            (user.getStatus() != null ? user.getStatus().name() : null),
             60*60*60L
         );
 

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/Business.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/Business.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 //BusinessVerification와 동일, 삭제 예정
 @Entity

--- a/src/main/java/com/umc/tomorrow/domain/member/dto/UserConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/dto/UserConverter.java
@@ -16,7 +16,7 @@ public class UserConverter {
                 .id(user.getId())
                 .email(user.getEmail())
                 .name(user.getName())
-                .gender(user.getGender() != null ? user.getGender().name() : null)
+                .gender(user.getGender() != null ? com.umc.tomorrow.domain.member.enums.Gender.valueOf(user.getGender().name()) : null)
                 .phoneNumber(user.getPhoneNumber())
                 .address(user.getAddress())
                 .status(user.getStatus() != null ? user.getStatus().name() : null)
@@ -33,7 +33,7 @@ public class UserConverter {
     public static void updateEntity(User user, UserDTO dto) {
         if (dto.getEmail() != null) user.setEmail(dto.getEmail());
         if (dto.getName() != null) user.setName(dto.getName());
-        if (dto.getGender() != null) user.setGender(User.Gender.valueOf(dto.getGender()));
+        if (dto.getGender() != null) user.setGender(User.Gender.valueOf(String.valueOf(dto.getGender())));
         if (dto.getPhoneNumber() != null) user.setPhoneNumber(dto.getPhoneNumber());
         if (dto.getAddress() != null) user.setAddress(dto.getAddress());
         if (dto.getStatus() != null) user.setStatus(User.Status.valueOf(dto.getStatus()));

--- a/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(name = "user")
 @Getter
 @Setter
 public class User {
@@ -46,7 +47,7 @@ public class User {
     @Column(length = 10, nullable = false)
     private Provider provider;
 
-    @Column(length = 10, nullable = false)
+    @Column(length = 255, nullable = false)
     private String providerUserId;
 
     @Column(nullable = false)

--- a/src/main/java/com/umc/tomorrow/domain/member/repository/UserRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/repository/UserRepository.java
@@ -1,9 +1,21 @@
+/**
+ * 회원(User) 엔티티의 데이터 접근을 위한 JpaRepository 인터페이스
+ * - Spring Data JPA를 이용하여 데이터베이스와의 상호작용을 추상화
+ *
+ * 작성자: 정여진진
+ * 생성일: 2025-07-10
+ */
 package com.umc.tomorrow.domain.member.repository;
 
 import com.umc.tomorrow.domain.member.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-
+  
+    /**
+     * 사용자 이름(username)으로 User 엔티티를 조회합니다.
+     * @param username 조회할 사용자의 이름
+     * @return 주어진 username에 해당하는 User 엔티티. 없으면 null 반환.
+     */
     User findByUsername(String username);
 }

--- a/src/main/java/com/umc/tomorrow/domain/preferences/controller/PreferenceController.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/controller/PreferenceController.java
@@ -1,0 +1,71 @@
+/**
+ * PreferenceController
+ * - 희망 조건 저장/수정 API 컨트롤러
+ * 
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
+package com.umc.tomorrow.domain.preferences.controller;
+
+import com.umc.tomorrow.domain.preferences.dto.PreferencesDTO;
+import com.umc.tomorrow.domain.preferences.service.PreferenceService;
+import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
+import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.Map;
+
+
+@Tag(name = "preference-controller", description = "희망 조건 관련 API")
+@RestController
+@RequestMapping("/api/v1/preferences")
+public class PreferenceController {
+    private final PreferenceService preferenceService;
+
+    @Autowired
+    public PreferenceController(PreferenceService preferenceService) {
+        this.preferenceService = preferenceService;
+    }
+
+    /**
+     * 희망 조건 수정 (PATCH)
+     * @param user 인증된 사용자
+     * @param dto 희망 조건 목록
+     * @return 저장 결과
+     */
+    @Operation(summary = "희망 조건 수정", description = "사용자의 희망 조건을 수정합니다.")
+    @PatchMapping
+    public ResponseEntity<BaseResponse> updatePreferences(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody PreferencesDTO dto) {
+        // 실제 DB에 희망 조건 업데이트
+        Long userId = user.getUserDTO().getId();
+        preferenceService.updatePreferences(userId, dto);
+        return ResponseEntity.ok(
+            BaseResponse.onSuccess(Map.of("saved", true))
+        );
+    }
+
+    /**
+     * 희망 조건 저장 (POST)
+     * @param user 인증된 사용자
+     * @param dto 희망 조건 목록
+     * @return 저장 결과
+     */
+    @Operation(summary = "희망 조건 저장", description = "사용자의 희망 조건을 최초로 저장합니다.")
+    @PostMapping
+    public ResponseEntity<BaseResponse> savePreferences(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody PreferencesDTO dto) {
+        Long userId = user.getUserDTO().getId();
+        preferenceService.savePreferences(userId, dto);
+        return ResponseEntity.ok(
+            BaseResponse.onSuccess(Map.of("saved", true))
+        );
+    }
+} 

--- a/src/main/java/com/umc/tomorrow/domain/preferences/converter/PreferenceConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/converter/PreferenceConverter.java
@@ -1,12 +1,15 @@
+/**
+ * PreferenceConverter
+ * - Preference Entity와 PreferencesDTO 간 변환 및 업데이트
+ * 
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
 package com.umc.tomorrow.domain.preferences.converter;
 
 import com.umc.tomorrow.domain.preferences.entity.Preference;
 import com.umc.tomorrow.domain.preferences.dto.PreferencesDTO;
 
-/**
- * PreferenceConverter
- * - Preference Entity와 PreferencesDTO 간 변환 및 업데이트
- */
 public class PreferenceConverter {
     /**
      * Entity -> DTO 변환

--- a/src/main/java/com/umc/tomorrow/domain/preferences/converter/PreferenceConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/converter/PreferenceConverter.java
@@ -1,0 +1,28 @@
+package com.umc.tomorrow.domain.preferences.converter;
+
+import com.umc.tomorrow.domain.preferences.entity.Preference;
+import com.umc.tomorrow.domain.preferences.dto.PreferencesDTO;
+
+/**
+ * PreferenceConverter
+ * - Preference Entity와 PreferencesDTO 간 변환 및 업데이트
+ */
+public class PreferenceConverter {
+    /**
+     * Entity -> DTO 변환
+     */
+    public static PreferencesDTO toDTO(Preference entity) {
+        return PreferencesDTO.builder()
+            .preferences(entity.getPreferences())
+            .build();
+    }
+
+    /**
+     * DTO -> Entity 업데이트
+     */
+    public static void updateEntity(Preference entity, PreferencesDTO dto) {
+        if (dto.getPreferences() != null) {
+            entity.setPreferences(dto.getPreferences());
+        }
+    }
+} 

--- a/src/main/java/com/umc/tomorrow/domain/preferences/dto/PreferencesDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/dto/PreferencesDTO.java
@@ -1,3 +1,10 @@
+/**
+ * PreferencesDTO
+ * - 사용자의 희망 조건 목록을 전달하는 DTO
+ * 
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
 package com.umc.tomorrow.domain.preferences.dto;
 
 import com.umc.tomorrow.domain.preferences.entity.PreferenceType;
@@ -5,10 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import java.util.Set;
 
-/**
- * PreferencesDTO
- * - 사용자의 희망 조건 목록을 전달하는 DTO
- */
+
 @Getter
 @Builder
 public class PreferencesDTO {

--- a/src/main/java/com/umc/tomorrow/domain/preferences/dto/PreferencesDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/dto/PreferencesDTO.java
@@ -1,0 +1,17 @@
+package com.umc.tomorrow.domain.preferences.dto;
+
+import com.umc.tomorrow.domain.preferences.entity.PreferenceType;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.Set;
+
+/**
+ * PreferencesDTO
+ * - 사용자의 희망 조건 목록을 전달하는 DTO
+ */
+@Getter
+@Builder
+public class PreferencesDTO {
+    /** 희망 조건 목록 */
+    private final Set<PreferenceType> preferences;
+} 

--- a/src/main/java/com/umc/tomorrow/domain/preferences/entity/Preference.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/entity/Preference.java
@@ -1,0 +1,38 @@
+package com.umc.tomorrow.domain.preferences.entity;
+
+import com.umc.tomorrow.domain.member.entity.User;
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Preference Entity
+ * - 사용자의 희망 조건(PreferenceType) 목록을 저장
+ */
+@Entity
+public class Preference {
+    /** 기본키 */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 희망 조건을 소유한 사용자
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    /**
+     * 희망 조건 목록 (EnumSet)
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    private Set<PreferenceType> preferences = new HashSet<>();
+
+    // Getter, Setter
+    public Long getId() { return id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public Set<PreferenceType> getPreferences() { return preferences; }
+    public void setPreferences(Set<PreferenceType> preferences) { this.preferences = preferences; }
+} 

--- a/src/main/java/com/umc/tomorrow/domain/preferences/entity/Preference.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/entity/Preference.java
@@ -1,17 +1,22 @@
+/**
+ * Preference Entity
+ * - 사용자의 희망 조건(PreferenceType) 목록을 저장
+ * 
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
 package com.umc.tomorrow.domain.preferences.entity;
 
 import com.umc.tomorrow.domain.member.entity.User;
 import jakarta.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
+import lombok.Builder;
 
-/**
- * Preference Entity
- * - 사용자의 희망 조건(PreferenceType) 목록을 저장
- */
 @Entity
+@Builder
 public class Preference {
-    /** 기본키 */
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/umc/tomorrow/domain/preferences/entity/PreferenceType.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/entity/PreferenceType.java
@@ -1,10 +1,12 @@
-package com.umc.tomorrow.domain.preferences.entity;
-
 /**
  * 희망 조건 ENUM
  * - 각 값은 사용자가 선택할 수 있는 일자리 희망 조건을 의미합니다.
  * - description 필드로 한글 설명 제공
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
  */
+package com.umc.tomorrow.domain.preferences.entity;
+
 public enum PreferenceType {
     SIT("앉아서 근무 중심"),
     STAND("서서 근무 중심"),

--- a/src/main/java/com/umc/tomorrow/domain/preferences/entity/PreferenceType.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/entity/PreferenceType.java
@@ -1,0 +1,28 @@
+package com.umc.tomorrow.domain.preferences.entity;
+
+/**
+ * 희망 조건 ENUM
+ * - 각 값은 사용자가 선택할 수 있는 일자리 희망 조건을 의미합니다.
+ * - description 필드로 한글 설명 제공
+ */
+public enum PreferenceType {
+    SIT("앉아서 근무 중심"),
+    STAND("서서 근무 중심"),
+    LIGHT_DELIVERY("가벼운 물건 운반"),
+    HEAVY_DELIVERY("무거운 물건 운반"),
+    PHYSICAL("신체 활동 중심"),
+    HUMAN("사람 응대 중심");
+
+    private final String description;
+
+    PreferenceType(String description) {
+        this.description = description;
+    }
+
+    /**
+     * 한글 설명 반환
+     */
+    public String getDescription() {
+        return description;
+    }
+} 

--- a/src/main/java/com/umc/tomorrow/domain/preferences/repository/PreferenceRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/repository/PreferenceRepository.java
@@ -1,0 +1,17 @@
+package com.umc.tomorrow.domain.preferences.repository;
+
+import com.umc.tomorrow.domain.preferences.entity.Preference;
+import com.umc.tomorrow.domain.member.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+/**
+ * PreferenceRepository
+ * - Preference Entity에 대한 JPA 데이터 접근 레이어
+ */
+public interface PreferenceRepository extends JpaRepository<Preference, Long> {
+    /**
+     * 사용자별 Preference 조회
+     */
+    Optional<Preference> findByUser(User user);
+} 

--- a/src/main/java/com/umc/tomorrow/domain/preferences/repository/PreferenceRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/repository/PreferenceRepository.java
@@ -1,3 +1,9 @@
+/**
+ * PreferenceRepository
+ * - Preference Entity에 대한 JPA 데이터 접근 레이어
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
 package com.umc.tomorrow.domain.preferences.repository;
 
 import com.umc.tomorrow.domain.preferences.entity.Preference;
@@ -5,10 +11,6 @@ import com.umc.tomorrow.domain.member.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
-/**
- * PreferenceRepository
- * - Preference Entity에 대한 JPA 데이터 접근 레이어
- */
 public interface PreferenceRepository extends JpaRepository<Preference, Long> {
     /**
      * 사용자별 Preference 조회

--- a/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceService.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceService.java
@@ -7,6 +7,7 @@
 package com.umc.tomorrow.domain.preferences.service;
 
 import com.umc.tomorrow.domain.preferences.dto.PreferencesDTO;
+
 public interface PreferenceService {
     /**
      * 희망 조건 저장

--- a/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceService.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceService.java
@@ -1,0 +1,20 @@
+/**
+ * PreferenceService
+ * - 희망 조건 저장/수정 비즈니스 로직 인터페이스
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
+package com.umc.tomorrow.domain.preferences.service;
+
+import com.umc.tomorrow.domain.preferences.dto.PreferencesDTO;
+public interface PreferenceService {
+    /**
+     * 희망 조건 저장
+     */
+    PreferencesDTO savePreferences(Long userId, PreferencesDTO dto);
+
+    /**
+     * 희망 조건 수정
+     */
+    PreferencesDTO updatePreferences(Long userId, PreferencesDTO dto);
+} 

--- a/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceServiceImpl.java
@@ -17,17 +17,13 @@ import com.umc.tomorrow.global.common.exception.code.GlobalErrorStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class PreferenceServiceImpl implements PreferenceService {
     private final PreferenceRepository preferenceRepository;
     private final UserRepository userRepository;
-
-    @Autowired
-    public PreferenceServiceImpl(PreferenceRepository preferenceRepository, UserRepository userRepository) {
-        this.preferenceRepository = preferenceRepository;
-        this.userRepository = userRepository;
-    }
 
     /**
      * 희망 조건 저장
@@ -37,9 +33,10 @@ public class PreferenceServiceImpl implements PreferenceService {
     public PreferencesDTO savePreferences(Long userId, PreferencesDTO dto) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
-        Preference entity = new Preference();
-        entity.setUser(user);
-        entity.setPreferences(dto.getPreferences());
+        Preference entity = Preference.builder()
+            .user(user)
+            .preferences(dto.getPreferences())
+            .build();
         preferenceRepository.save(entity);
         return PreferenceConverter.toDTO(entity);
     }

--- a/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/preferences/service/PreferenceServiceImpl.java
@@ -1,0 +1,61 @@
+/**
+ * PreferenceServiceImpl
+ * - 희망 조건 저장/수정 비즈니스 로직 구현체
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
+package com.umc.tomorrow.domain.preferences.service;
+
+import com.umc.tomorrow.domain.preferences.dto.PreferencesDTO;
+import com.umc.tomorrow.domain.preferences.entity.Preference;
+import com.umc.tomorrow.domain.preferences.repository.PreferenceRepository;
+import com.umc.tomorrow.domain.preferences.converter.PreferenceConverter;
+import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.member.repository.UserRepository;
+import com.umc.tomorrow.global.common.exception.RestApiException;
+import com.umc.tomorrow.global.common.exception.code.GlobalErrorStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PreferenceServiceImpl implements PreferenceService {
+    private final PreferenceRepository preferenceRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public PreferenceServiceImpl(PreferenceRepository preferenceRepository, UserRepository userRepository) {
+        this.preferenceRepository = preferenceRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 희망 조건 저장
+     */
+    @Override
+    @Transactional
+    public PreferencesDTO savePreferences(Long userId, PreferencesDTO dto) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
+        Preference entity = new Preference();
+        entity.setUser(user);
+        entity.setPreferences(dto.getPreferences());
+        preferenceRepository.save(entity);
+        return PreferenceConverter.toDTO(entity);
+    }
+
+    /**
+     * 희망 조건 수정
+     */
+    @Override
+    @Transactional
+    public PreferencesDTO updatePreferences(Long userId, PreferencesDTO dto) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
+        Preference entity = preferenceRepository.findByUser(user)
+            .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
+        PreferenceConverter.updateEntity(entity, dto);
+        preferenceRepository.save(entity);
+        return PreferenceConverter.toDTO(entity);
+    }
+} 

--- a/src/main/java/com/umc/tomorrow/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/controller/ReviewController.java
@@ -1,0 +1,53 @@
+/**
+ * ReviewController
+ * - 후기 작성 API 컨트롤러
+ *
+ * 작성자: 정여진진
+ * 생성일: 2025-07-17
+ */
+package com.umc.tomorrow.domain.review.controller;
+
+import com.umc.tomorrow.domain.review.dto.ReviewRequestDTO;
+import com.umc.tomorrow.domain.review.service.ReviewService;
+import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
+import com.umc.tomorrow.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Tag(name = "review-controller", description = "후기 관련 API")
+@RestController
+@RequestMapping("/api/v1/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Autowired
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    /**
+     * 후기 작성 (POST)
+     * @param user 인증된 사용자
+     * @param dto 후기 요청 DTO
+     * @return 저장 결과
+     */
+    @Operation(summary = "후기 작성", description = "공고에 대한 후기를 작성합니다.")
+    @PostMapping
+    public ResponseEntity<BaseResponse> saveReview(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody ReviewRequestDTO dto) {
+        // 실제 DB에 후기 저장
+        Long userId = user.getUserDTO().getId();
+        reviewService.saveReview(userId, dto);
+        return ResponseEntity.ok(
+                BaseResponse.onSuccess(Map.of("saved", true))
+        );
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/review/dto/ReviewConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/dto/ReviewConverter.java
@@ -1,0 +1,16 @@
+package com.umc.tomorrow.domain.review.dto;
+
+import com.umc.tomorrow.domain.review.dto.ReviewRequestDTO;
+import com.umc.tomorrow.domain.review.entity.Review;
+import com.umc.tomorrow.domain.member.entity.User;
+
+public class ReviewConverter {
+    public static Review toEntity(ReviewRequestDTO dto, User user) {
+        return Review.builder()
+                .postId(dto.getPostId())
+                .stars(dto.getStars())
+                .review(dto.getReview())
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/dto/ReviewRequestDTO.java
@@ -1,0 +1,19 @@
+/**
+ * 후기(리뷰) ReviewRequestDTO
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-11
+ */
+package com.umc.tomorrow.domain.review.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewRequestDTO {
+    private Long postId;
+    private int stars;
+    private String review;
+}

--- a/src/main/java/com/umc/tomorrow/domain/review/entity/Review.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/entity/Review.java
@@ -1,0 +1,32 @@
+/**
+ * 후기(리뷰) entity
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-11
+ */
+package com.umc.tomorrow.domain.review.entity;
+
+import com.umc.tomorrow.domain.member.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long postId;
+
+    private int stars;
+
+    @Column(length = 100)
+    private String review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+}

--- a/src/main/java/com/umc/tomorrow/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,13 @@
+/**
+ * ReviewRepository
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
+package com.umc.tomorrow.domain.review.repository;
+
+import com.umc.tomorrow.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/umc/tomorrow/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/service/ReviewService.java
@@ -1,0 +1,19 @@
+/**
+ * ReviewService
+ * - 후기 저장 비즈니스 로직 인터페이스
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
+package com.umc.tomorrow.domain.review.service;
+
+import com.umc.tomorrow.domain.review.dto.ReviewRequestDTO;
+
+public interface ReviewService {
+    /**
+     * 후기 저장
+     * @param userId 회원 ID
+     * @param dto 후기 요청 DTO
+     */
+    void saveReview(Long userId, ReviewRequestDTO dto);
+}

--- a/src/main/java/com/umc/tomorrow/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,49 @@
+/**
+ * ReviewServiceImpl
+ * - 후기 저장 비즈니스 로직 구현체
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-17
+ */
+package com.umc.tomorrow.domain.review.service;
+
+import com.umc.tomorrow.domain.review.dto.ReviewRequestDTO;
+import com.umc.tomorrow.domain.review.entity.Review;
+import com.umc.tomorrow.domain.review.repository.ReviewRepository;
+import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.member.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ReviewServiceImpl implements ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public ReviewServiceImpl(ReviewRepository reviewRepository, UserRepository userRepository) {
+        this.reviewRepository = reviewRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 후기 저장
+     * @param userId 회원 ID
+     * @param dto 후기 요청 DTO
+     */
+    @Transactional
+    @Override
+    public void saveReview(Long userId, ReviewRequestDTO dto) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+        Review review = Review.builder()
+                .postId(dto.getPostId())
+                .stars(dto.getStars())
+                .review(dto.getReview())
+                .user(user)
+                .build();
+        reviewRepository.save(review);
+    }
+}

--- a/src/main/resources/validation.properties
+++ b/src/main/resources/validation.properties
@@ -1,4 +1,5 @@
-# UserDTO Validation Messages
+# validation.properties
+# UserDTO의 각 필드별 validation 메시지 정의
 user.email.notblank=이메일은 필수입니다.
 user.email.invalid=이메일 형식이 올바르지 않습니다.
 user.email.size=이메일은 30자 이내여야 합니다.


### PR DESCRIPTION
## 관련 이슈
- close #이슈번호

## PR 유형
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링


## 작업 내용
Feat:
- 사용자의 희망 조건을 저장(POST)하고 수정(PATCH)하는 새로운 PreferenceController API 엔드포인트 추가했습니다.
- DTO-엔티티 변환 및 업데이트를 위한 PreferenceConverter를 구현했습니다.
- 사용자 희망 조건 데이터 관리를 위한 PreferenceService 및 PreferenceRepository를 구현했습니다.

Fix:
- `User` 엔티티의 `providerUserId` 컬럼 길이를 255로 늘려 `Data truncation` 오류를 해결했습니다.
- `User` 엔티티에 `@Table(name="user")`를 명시적으로 추가하여 중복 테이블 생성(`user`, `user_entity`) 문제를 해결했습니다.
- JWTUtil에 필요없다고 생각했던 username, role을 다시 복구했습니다. (있어야 정상 작동)
- 사용자 또는 희망 조건을 찾을 수 없는 상황에서 `RestApiException`과 `GlobalErrorStatus._NOT_FOUND`를 던지도록 `PreferenceController`를 리팩토링하여 더 구체적인 오류 처리를 제공하도록 수정했습니다.
- Gender는 enum으로 따로 뺐습니다. (JWTFilter에 잘못 들어가 있었습니다.)

## 리뷰 포인트
- 리뷰어가 확인해주면 좋을 부분이 있다면 작성해 주세요.

## 🖼스크린샷 (선택)
- post /api/v1/preferences 200 (성공시)를 확인한 swagger 캡쳐본입니다.
<img width="752" height="582" alt="image" src="https://github.com/user-attachments/assets/74d2e451-ed6a-48c1-9f81-39e3a14ad0a0" />
- patch /api/v1/preferences 200 (성공시)를 확인한 swagger 캡쳐본입니다.
<img width="741" height="687" alt="image" src="https://github.com/user-attachments/assets/ae7e23cd-0f19-4a0f-b2c8-7a551eca0062" />
- patch /api/v1/preferences 500 (서버에러)를 확인한 swagger 캡쳐본입니다.
<img width="1861" height="652" alt="image" src="https://github.com/user-attachments/assets/3014b702-688c-4e18-837c-8ab6ec177c33" />

