### PR TITLE
Feat/Add 후기 작성 기능

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/review/entity/Review.java
+++ b/src/main/java/com/umc/tomorrow/domain/review/entity/Review.java
@@ -9,6 +9,7 @@ package com.umc.tomorrow.domain.review.entity;
 import com.umc.tomorrow.domain.member.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,13 +21,17 @@ public class Review {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull(message = "{review.postId.notnull}")
     private Long postId;
 
+    @NotNull(message = "{review.stars.notnull}")
     private int stars;
 
+    @NotNull(message = "{review.review.notnull}")
     @Column(length = 100)
     private String review;
 
+    @NotNull(message = "{review.user.notnull}")
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 }

--- a/src/main/resources/validation.properties
+++ b/src/main/resources/validation.properties
@@ -14,4 +14,10 @@ user.isOnboarded.notnull=온보딩 여부는 필수입니다.
 user.provider.notnull=소셜 제공자는 필수입니다.
 user.providerUserId.notblank=소셜 제공자 ID는 필수입니다.
 user.providerUserId.size=소셜 제공자 ID는 10자 이내여야 합니다.
-user.resumeId.notnull=이력서 ID는 필수입니다. 
+user.resumeId.notnull=이력서 ID는 필수입니다.
+
+# 리뷰 등록
+review.postId.notnull=공고 ID는 필수입니다.
+review.stars.notnull=별점은 필수입니다.
+review.review.notnull=리뷰 내용은 필수입니다.
+review.user.notnull=작성자는 필수입니다. 


### PR DESCRIPTION
Resolves #24

## 관련 이슈
- close #이슈번호

## PR 유형
- [ ] 기능 추가

## 작업 내용
- 공고에 대한 후기 작성 API 개발

- ReviewController에 POST /api/v1/reviews 엔드포인트 구현
- ReviewRequestDTO 및 Review 엔티티 정의
- ReviewRepository와 ReviewService를 활용하여 비즈니스 로직 처리
- 후기 작성 시 Authorization 헤더의 Bearer 토큰을 통해 사용자 인증 및 ID 참조 구현

## 리뷰 포인트
- 없습니다.

## 🖼스크린샷 (선택)
- post /api/v1/reviews (200) 성공했을 경우의 swagger 화면 캡쳐본
<img width="838" height="849" alt="image" src="https://github.com/user-attachments/assets/4bf34bc8-1cf3-48ea-b7a6-c092ef15ff7f" />

-  post /api/v1/reviews (400) 실패했을 경우의 swagger 화면 캡쳐본
<img width="904" height="862" alt="image" src="https://github.com/user-attachments/assets/e2a0ec8e-2760-490c-b701-bd65ed50fdf8" />

