### PR TITLE
Feat/회원 탈퇴, 회원 복구 api구현

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
@@ -2,6 +2,7 @@ package com.umc.tomorrow.domain.auth.security;
 
 import com.umc.tomorrow.domain.auth.jwt.JWTUtil;
 import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.member.enums.Provider;
 import com.umc.tomorrow.domain.member.repository.UserRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -44,7 +45,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String providerStr = customUserDetails.getUserDTO().getProvider();
         String providerUserId = customUserDetails.getUserDTO().getProviderUserId();
-        User.Provider provider = User.Provider.valueOf(providerStr.toUpperCase());
+        Provider provider = Provider.valueOf(providerStr.toUpperCase());
 
         User user = userRepository.findByProviderAndProviderUserId(provider, providerUserId);
         if (user == null) {
@@ -58,7 +59,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             providerStr = customUserDetails.getUserDTO().getProvider();
             providerUserId = customUserDetails.getUserDTO().getProviderUserId();
             if (providerStr != null) {
-                user.setProvider(User.Provider.valueOf(providerStr.toUpperCase()));
+                user.setProvider(Provider.valueOf(providerStr.toUpperCase()));
             }
             user.setProviderUserId(providerUserId);
             // username은 provider + '_' + providerUserId로 생성

--- a/src/main/java/com/umc/tomorrow/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/controller/MemberController.java
@@ -9,7 +9,12 @@
 package com.umc.tomorrow.domain.member.controller;
 
 import com.umc.tomorrow.domain.member.dto.UserDTO;
+import com.umc.tomorrow.domain.member.dto.request.DeactivateUserRequest;
+import com.umc.tomorrow.domain.member.dto.response.DeactivateUserResponse;
+import com.umc.tomorrow.domain.member.dto.response.RecoverUserResponse;
+import com.umc.tomorrow.global.common.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
 import com.umc.tomorrow.domain.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.umc.tomorrow.domain.member.exception.MemberStatus;
 
 @Tag(name = "member-controller", description = "회원 관련 API")
 @RestController
@@ -50,4 +56,22 @@ public class MemberController {
         UserDTO updated = memberService.updateUser(user.getUserDTO(), userDTO);
         return ResponseEntity.ok(updated);
     }
-} 
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 API입니다. 14일 내로 복구가 가능합니다.")
+    @PatchMapping("/{memberId}/deactivate")
+    public ResponseEntity<BaseResponse<DeactivateUserResponse>> deactivateUser(
+            @PathVariable("memberId") Long memberId,
+            @RequestBody DeactivateUserRequest request
+    ) {
+        DeactivateUserResponse result = memberService.deactivateUser(memberId, request);
+        return ResponseEntity.ok(BaseResponse.of(MemberStatus.MEMBER_DEACTIVATED, result));
+    }
+    @Operation(summary = "회원 복구", description = "14일 내에 탈퇴한 회원만 복구 가능합니다.")
+    @PatchMapping("/{memberId}/recover")
+    public ResponseEntity<BaseResponse<RecoverUserResponse>> recoverUser(
+            @PathVariable("memberId") Long memberId
+    ) {
+        RecoverUserResponse result = memberService.recoverUser(memberId);
+        return ResponseEntity.ok(BaseResponse.of(MemberStatus.MEMBER_RECOVERED, result));
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/dto/UserConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/dto/UserConverter.java
@@ -8,6 +8,9 @@
 package com.umc.tomorrow.domain.member.dto;
 
 import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.member.enums.Gender;
+import com.umc.tomorrow.domain.member.enums.Provider;
+import com.umc.tomorrow.domain.member.enums.UserStatus;
 
 public class UserConverter {
     public static UserDTO toDTO(User user) {
@@ -33,13 +36,13 @@ public class UserConverter {
     public static void updateEntity(User user, UserDTO dto) {
         if (dto.getEmail() != null) user.setEmail(dto.getEmail());
         if (dto.getName() != null) user.setName(dto.getName());
-        if (dto.getGender() != null) user.setGender(User.Gender.valueOf(String.valueOf(dto.getGender())));
+        if (dto.getGender() != null) user.setGender(Gender.valueOf(String.valueOf(dto.getGender())));
         if (dto.getPhoneNumber() != null) user.setPhoneNumber(dto.getPhoneNumber());
         if (dto.getAddress() != null) user.setAddress(dto.getAddress());
-        if (dto.getStatus() != null) user.setStatus(User.Status.valueOf(dto.getStatus()));
+        if (dto.getStatus() != null) user.setStatus(UserStatus.valueOf(dto.getStatus()));
         if (dto.getInactiveAt() != null) user.setInactiveAt(dto.getInactiveAt());
         if (dto.getIsOnboarded() != null) user.setIsOnboarded(dto.getIsOnboarded());
-        if (dto.getProvider() != null) user.setProvider(User.Provider.valueOf(dto.getProvider()));
+        if (dto.getProvider() != null) user.setProvider(Provider.valueOf(dto.getProvider()));
         if (dto.getProviderUserId() != null) user.setProviderUserId(dto.getProviderUserId());
         if (dto.getCreatedAt() != null) user.setCreatedAt(dto.getCreatedAt());
         if (dto.getUpdatedAt() != null) user.setUpdatedAt(dto.getUpdatedAt());

--- a/src/main/java/com/umc/tomorrow/domain/member/dto/request/DeactivateUserRequest.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/dto/request/DeactivateUserRequest.java
@@ -1,0 +1,19 @@
+/**
+ * DeactivateUserRequest
+ * - patch /api/v1/users/{userId}/deactivate
+ * 작성자: 정여진
+ * body : {
+ *   "status": "DELETED"
+ * }
+ * 생성일: 2025-07-23
+ */
+package com.umc.tomorrow.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DeactivateUserRequest {
+    @NotBlank(message = "{user.status.notnull}")
+    private String status; // "DELETED"
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/dto/response/DeactivateUserResponse.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/dto/response/DeactivateUserResponse.java
@@ -1,0 +1,20 @@
+/**
+ * DeactivateUserResponse (회원상태)
+ - patch /api/v1/members/{memberId}/deactivate
+ * 작성자: 정여진
+ * 생성일: 2025-07-23
+ */
+package com.umc.tomorrow.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DeactivateUserResponse {
+    private String status;
+    private LocalDateTime deletedAt;
+    private LocalDateTime recoverableUntil;
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/dto/response/RecoverUserResponse.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/dto/response/RecoverUserResponse.java
@@ -1,0 +1,19 @@
+/**
+ * RecoverUserResponse (회원복구)
+ - patch /api/v1/members/{memberId}/recover
+ * 작성자: 정여진
+ * 생성일: 2025-07-23
+ */
+package com.umc.tomorrow.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RecoverUserResponse {
+    private String status;
+    private LocalDateTime recoveredAt;
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
@@ -1,6 +1,9 @@
 package com.umc.tomorrow.domain.member.entity;
 
 import com.umc.tomorrow.domain.job.entity.Job;
+import com.umc.tomorrow.domain.member.enums.Gender;
+import com.umc.tomorrow.domain.member.enums.Provider;
+import com.umc.tomorrow.domain.member.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,7 +40,7 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(length = 10)
-    private Status status;
+    private UserStatus status;
 
     private LocalDateTime inactiveAt;
 
@@ -68,16 +71,4 @@ public class User {
     //연관관계
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Job> jobs = new ArrayList<>(); // 내가 등록한 일자리 목록
-
-    public enum Gender {
-        MALE, FEMALE
-    }
-
-    public enum Status {
-        ACTIVE, INACTIVE
-    }
-
-    public enum Provider {
-        KAKAO, NAVER, GOOGLE
-    }
 }

--- a/src/main/java/com/umc/tomorrow/domain/member/enums/Provider.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/enums/Provider.java
@@ -1,0 +1,10 @@
+/**
+ * Provider (소셜로그인)
+ * 작성자: 정여진
+ * 생성일: 2025-07-23
+ */
+package com.umc.tomorrow.domain.member.enums;
+
+public enum Provider {
+    KAKAO, NAVER, GOOGLE
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/enums/UserStatus.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/enums/UserStatus.java
@@ -1,0 +1,12 @@
+/**
+ * UserStatus (회원상태)
+ * 작성자: 정여진
+ * 생성일: 2025-07-23
+ */
+package com.umc.tomorrow.domain.member.enums;
+
+public enum UserStatus {
+    ACTIVE,
+    DELETED, // 탈퇴 상태 (14일 내 복구 가능)
+    INACTIVE // 휴면 상태 또는 비활성화
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/exception/MemberStatus.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/exception/MemberStatus.java
@@ -1,0 +1,35 @@
+package com.umc.tomorrow.domain.member.exception;
+
+import com.umc.tomorrow.global.common.exception.code.BaseCode;
+import com.umc.tomorrow.global.common.exception.code.BaseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberStatus implements BaseCodeInterface {
+
+    // 200번대 성공
+    MEMBER_DEACTIVATED(HttpStatus.OK, true, "MEMBER2002", "회원 탈퇴가 완료되었습니다."),
+    MEMBER_RECOVERED(HttpStatus.OK, true, "MEMBER2003", "회원 복구가 완료되었습니다."),
+
+    // 400번대 실패
+    INVALID_RECOVERY_PERIOD(HttpStatus.BAD_REQUEST, false, "MEMBER4001", "복구 가능 기간이 지났습니다."),
+    NOT_DELETED_USER(HttpStatus.BAD_REQUEST, false, "MEMBER4002", "탈퇴한 회원이 아닙니다.");
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCode getCode() {
+        return BaseCode.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/member/repository/UserRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/repository/UserRepository.java
@@ -8,6 +8,7 @@
 package com.umc.tomorrow.domain.member.repository;
 
 import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.member.enums.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -18,6 +19,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * @return 주어진 username에 해당하는 User 엔티티. 없으면 null 반환.
      */
     User findByUsername(String username);
-    User findByProviderAndProviderUserId(User.Provider provider, String providerUserId);
-
+    User findByProviderAndProviderUserId(Provider provider, String providerUserId);
 }

--- a/src/main/resources/validation.properties
+++ b/src/main/resources/validation.properties
@@ -26,3 +26,4 @@ review.user.notnull=작성자는 필수입니다.
 careertalk.category.notblank=카테고리 선택은 필수입니다.
 careertalk.title.notblank=제목은 필수입니다.
 careertalk.content.notblank=내용은 필수입니다.
+


### PR DESCRIPTION
## 관련 이슈
- close #이슈번호

## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 회원 탈퇴, 회원 복구에 대한 api 구현했습니다.
- member에 enums가 user entity안에 있어, 밖으로 따로 뺐습니다.

## 리뷰 포인트
- 리뷰어가 확인해주면 좋을 부분이 있다면 작성해 주세요.

## 🖼스크린샷 (선택)
- swagger 캡쳐입니다. (회원 탈퇴 patch /api/v1/members/{memberId}/deactivate)
<img width="821" height="717" alt="image" src="https://github.com/user-attachments/assets/ec6f5832-4f7d-488d-a7b0-6205550531b4" />
<img width="622" height="792" alt="image" src="https://github.com/user-attachments/assets/efdb0048-110a-4c08-96f6-af71d1e5a9e0" />

- swagger 캡쳐입니다. (회원 복구 patch /api/v1/members/{memberId}/recover)
<img width="1005" height="863" alt="image" src="https://github.com/user-attachments/assets/3c3587ff-4100-4317-a53b-cfdf44a0093b" />

