### PR TITLE
Feat: 커리어톡 제목 및 카테고리로 게시글 목록 조회 API

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
@@ -22,6 +22,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -51,11 +53,12 @@ public class CareertalkController {
     @PostMapping
     @Operation(summary = "커리어톡 게시글 작성", description = "로그인한 사용자가 커리어톡 게시글을 작성합니다.")
     @ApiResponse(responseCode = "201", description = "게시글 생성 성공")
-    public BaseResponse<CareertalkResponseDto> createCareertalk(
+    public ResponseEntity<BaseResponse<CareertalkResponseDto>> createCareertalk(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             @Valid @RequestBody CreateCareertalkRequestDto requestDto
     ) {
-        return BaseResponse.onSuccessCreate(careertalkCommandService.createCareertalk(customOAuth2User.getUserDTO().getId(), requestDto));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BaseResponse.onSuccessCreate(careertalkCommandService.createCareertalk(customOAuth2User.getUserDTO().getId(), requestDto)));
     }
 
     /**
@@ -67,11 +70,11 @@ public class CareertalkController {
     @GetMapping
     @Operation(summary = "커리어톡 게시글 목록 조회 (무한 스크롤)", description = "커리어톡 게시글 목록을 무한 스크롤 방식으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공")
-    public BaseResponse<GetCareertalkListResponseDto> getCareertalks(
+    public ResponseEntity<BaseResponse<GetCareertalkListResponseDto>> getCareertalks(
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "8") int size
     ) {
-        return BaseResponse.onSuccess(careertalkQueryService.getCareertalks(cursor, size));
+        return ResponseEntity.ok(BaseResponse.onSuccess(careertalkQueryService.getCareertalks(cursor, size)));
     }
 
     /**
@@ -82,10 +85,10 @@ public class CareertalkController {
     @GetMapping("/{careertalkId}")
     @Operation(summary = "커리어톡 게시글 상세 조회", description = "커리어톡 게시글을 상세 조회합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공")
-    public BaseResponse<GetCareertalkResponseDto> getCareertalk(
+    public ResponseEntity<BaseResponse<GetCareertalkResponseDto>> getCareertalk(
             @PathVariable Long careertalkId
     ) {
-        return BaseResponse.onSuccess(careertalkQueryService.getCareertalk(careertalkId));
+        return ResponseEntity.ok(BaseResponse.onSuccess(careertalkQueryService.getCareertalk(careertalkId)));
     }
 
     /**
@@ -97,21 +100,27 @@ public class CareertalkController {
     @PutMapping("/{careertalkId}")
     @Operation(summary = "커리어톡 게시글 수정", description = "로그인한 사용자가 커리어톡 게시글을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 수정 성공")
-    public BaseResponse<CareertalkResponseDto> updateCareertalk(
+    public ResponseEntity<BaseResponse<CareertalkResponseDto>> updateCareertalk(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             @PathVariable Long careertalkId,
             @Valid @RequestBody UpdateCareertalkRequestDto requestDto
     ){
-        return BaseResponse.onSuccess(careertalkCommandService.updateCareertalk(customOAuth2User.getUserDTO().getId(),careertalkId,requestDto));
+        return ResponseEntity.ok(BaseResponse.onSuccess(careertalkCommandService.updateCareertalk(customOAuth2User.getUserDTO().getId(),careertalkId,requestDto)));
     }
 
+    /**
+     * 커리어톡 게시글 삭제 API
+     * @param customOAuth2User 인증된 사용자
+     * @param careertalkId 게시글 Id
+     * @return 커리어톡 응답 DTO
+     */
     @DeleteMapping("/{careertalkId}")
     @Operation(summary = "커리어톡 게시글 삭제", description = "로그인한 사용자가 커리어톡 게시글을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 삭제 성공")
-    public BaseResponse<CareertalkResponseDto> deleteCareertalk(
+    public ResponseEntity<BaseResponse<CareertalkResponseDto>> deleteCareertalk(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             @PathVariable Long careertalkId
     ){
-        return BaseResponse.onSuccessDelete(careertalkCommandService.deleteCareertalk(customOAuth2User.getUserDTO().getId(),careertalkId));
+        return ResponseEntity.ok(BaseResponse.onSuccessDelete(careertalkCommandService.deleteCareertalk(customOAuth2User.getUserDTO().getId(),careertalkId)));
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
@@ -123,4 +123,36 @@ public class CareertalkController {
     ){
         return ResponseEntity.ok(BaseResponse.onSuccessDelete(careertalkCommandService.deleteCareertalk(customOAuth2User.getUserDTO().getId(),careertalkId)));
     }
+
+    /**
+     * 커리어톡 게시글 제목으로 검색 API
+     * @param title 커리어톡 게시글
+     * @return 커리어톡 게시글 목록 DTO
+     */
+    @GetMapping("/search/title")
+    @Operation(summary = "커리어톡 게시글 제목으로 검색", description = "로그인한 사용자가 커리어톡 게시글을 제목으로 검색하여 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 조회 성공")
+    public ResponseEntity<BaseResponse<GetCareertalkListResponseDto>> getCareertalksByTitle(
+            @RequestParam String title,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "8") int size
+    ){
+        return ResponseEntity.ok(BaseResponse.onSuccess(careertalkQueryService.getCareertalksByTitle(title,cursor,size)));
+    }
+
+    /**
+     * 커리어톡 게시글 카테고리로 검색 API
+     * @param category 커리어톡 게시글 카테고리
+     * @return 커리어톡 게시글 목록 DTO
+     */
+    @GetMapping("/search/category")
+    @Operation(summary = "커리어톡 게시글 카테고리로 검색", description = "로그인한 사용자가 커리어톡 게시글을 카테고리로 검색하여 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 조회 성공")
+    public ResponseEntity<BaseResponse<GetCareertalkListResponseDto>> getCareertalksByCategory(
+            @RequestParam String category,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "8") int size
+    ){
+        return ResponseEntity.ok(BaseResponse.onSuccess(careertalkQueryService.getCareertalksByCategory(category,cursor,size)));
+    }
 }

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
@@ -9,7 +9,8 @@ package com.umc.tomorrow.domain.careertalk.controller;
 
 import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
 import com.umc.tomorrow.domain.careertalk.dto.request.CreateCareertalkRequestDto;
-import com.umc.tomorrow.domain.careertalk.dto.response.CreateCareertalkResponseDto;
+import com.umc.tomorrow.domain.careertalk.dto.request.UpdateCareertalkRequestDto;
+import com.umc.tomorrow.domain.careertalk.dto.response.CareertalkResponseDto;
 import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkListResponseDto;
 import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkResponseDto;
 import com.umc.tomorrow.domain.careertalk.service.command.CareertalkCommandService;
@@ -22,9 +23,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,17 +46,16 @@ public class CareertalkController {
      * 커리어톡 게시글 저장(POST)
      * @param customOAuth2User 인증된 사용자
      * @param requestDto 게시글 생성 요청 DTO
-     * @return 커리어톡 생성 응답 DTO
+     * @return 커리어톡 응답 DTO
      */
     @PostMapping
     @Operation(summary = "커리어톡 게시글 작성", description = "로그인한 사용자가 커리어톡 게시글을 작성합니다.")
     @ApiResponse(responseCode = "201", description = "게시글 생성 성공")
-    public BaseResponse<CreateCareertalkResponseDto> createCareertalk(
+    public BaseResponse<CareertalkResponseDto> createCareertalk(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             @Valid @RequestBody CreateCareertalkRequestDto requestDto
     ) {
-        String username = customOAuth2User.getName();
-        return BaseResponse.onSuccessCreate(careertalkCommandService.createCareertalk(username, requestDto));
+        return BaseResponse.onSuccessCreate(careertalkCommandService.createCareertalk(customOAuth2User.getUserDTO().getId(), requestDto));
     }
 
     /**
@@ -84,5 +86,32 @@ public class CareertalkController {
             @PathVariable Long careertalkId
     ) {
         return BaseResponse.onSuccess(careertalkQueryService.getCareertalk(careertalkId));
+    }
+
+    /**
+     * 커리어톡 게시글 수정 API
+     * @param customOAuth2User 인증된 사용자
+     * @param requestDto 게시글 수정 요청 DTO
+     * @return 커리어톡 응답 DTO
+     */
+    @PutMapping("/{careertalkId}")
+    @Operation(summary = "커리어톡 게시글 수정", description = "로그인한 사용자가 커리어톡 게시글을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 수정 성공")
+    public BaseResponse<CareertalkResponseDto> updateCareertalk(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @PathVariable Long careertalkId,
+            @Valid @RequestBody UpdateCareertalkRequestDto requestDto
+    ){
+        return BaseResponse.onSuccess(careertalkCommandService.updateCareertalk(customOAuth2User.getUserDTO().getId(),careertalkId,requestDto));
+    }
+
+    @DeleteMapping("/{careertalkId}")
+    @Operation(summary = "커리어톡 게시글 삭제", description = "로그인한 사용자가 커리어톡 게시글을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 삭제 성공")
+    public BaseResponse<CareertalkResponseDto> deleteCareertalk(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @PathVariable Long careertalkId
+    ){
+        return BaseResponse.onSuccessDelete(careertalkCommandService.deleteCareertalk(customOAuth2User.getUserDTO().getId(),careertalkId));
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
@@ -127,6 +127,8 @@ public class CareertalkController {
     /**
      * 커리어톡 게시글 제목으로 검색 API
      * @param title 커리어톡 게시글
+     * @param cursor 이전 요청에서의 마지막 게시글 id
+     * @param size 요청한 게시글 개수
      * @return 커리어톡 게시글 목록 DTO
      */
     @GetMapping("/search/title")
@@ -143,6 +145,8 @@ public class CareertalkController {
     /**
      * 커리어톡 게시글 카테고리로 검색 API
      * @param category 커리어톡 게시글 카테고리
+     * @param cursor 이전 요청에서의 마지막 게시글 id
+     * @param size 요청한 게시글 개수
      * @return 커리어톡 게시글 목록 DTO
      */
     @GetMapping("/search/category")

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/converter/CareertalkConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/converter/CareertalkConverter.java
@@ -6,7 +6,7 @@
  */
 package com.umc.tomorrow.domain.careertalk.converter;
 
-import com.umc.tomorrow.domain.careertalk.dto.response.CreateCareertalkResponseDto;
+import com.umc.tomorrow.domain.careertalk.dto.response.CareertalkResponseDto;
 import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkResponseDto;
 import com.umc.tomorrow.domain.careertalk.entity.Careertalk;
 
@@ -14,8 +14,8 @@ public class CareertalkConverter {
     /**
      * Careertalk 엔티티로부터 커리어톡 생성 DTO로 변환
      */
-    public static CreateCareertalkResponseDto toCreateCareertalkResponseDto(Careertalk careertalk) {
-        return CreateCareertalkResponseDto.builder()
+    public static CareertalkResponseDto toCareertalkResponseDto(Careertalk careertalk) {
+        return CareertalkResponseDto.builder()
                 .id(careertalk.getId())
                 .build();
     }

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/dto/request/CreateCareertalkRequestDto.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/dto/request/CreateCareertalkRequestDto.java
@@ -9,6 +9,7 @@ package com.umc.tomorrow.domain.careertalk.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,6 +24,7 @@ public class CreateCareertalkRequestDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     @NotBlank(message = "careertalk.category.notblank")
+    @Size(max = 20, message = "careertalk.category.size")
     private String category;
 
     @Schema(
@@ -31,6 +33,7 @@ public class CreateCareertalkRequestDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     @NotBlank(message = "careertalk.title.notblank")
+    @Size(max = 50, message = "careertalk.title.size")
     private String title;
 
     @Schema(

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/dto/request/UpdateCareertalkRequestDto.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/dto/request/UpdateCareertalkRequestDto.java
@@ -8,6 +8,7 @@ package com.umc.tomorrow.domain.careertalk.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,6 +23,7 @@ public class UpdateCareertalkRequestDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     @NotBlank(message = "careertalk.category.notblank")
+    @Size(max = 20, message = "careertalk.category.size")
     private String category;
 
     @Schema(
@@ -30,6 +32,7 @@ public class UpdateCareertalkRequestDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     @NotBlank(message = "careertalk.title.notblank")
+    @Size(max = 50, message = "careertalk.title.size")
     private String title;
 
     @Schema(

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/dto/request/UpdateCareertalkRequestDto.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/dto/request/UpdateCareertalkRequestDto.java
@@ -1,0 +1,42 @@
+/**
+ * 커리어톡 게시글 수정 요청 DTO
+ * 커리어톡 게시글 수정 API의 요청 구조 정의
+ * 작성자: 이승주
+ * 생성일: 2025-07-23
+ */
+package com.umc.tomorrow.domain.careertalk.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "커리어톡 게시글 수정 요청 DTO")
+public class UpdateCareertalkRequestDto {
+
+    @Schema(
+            description = "게시글 카테고리",
+            example = "INTERVIEW",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "careertalk.category.notblank")
+    private String category;
+
+    @Schema(
+            description = "게시글 제목",
+            example = "커리어 인터뷰 준비 방법 공유합니다!",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "careertalk.title.notblank")
+    private String title;
+
+    @Schema(
+            description = "게시글 본문 내용",
+            example = "안녕하세요! 저는 최근에 취업 준비하면서 이렇게 준비했어요..."
+    )
+    @NotBlank(message = "careertalk.content.notblank")
+    private String content;
+
+}

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/dto/response/CareertalkResponseDto.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/dto/response/CareertalkResponseDto.java
@@ -3,7 +3,7 @@
  * 커리어톡 게시글 생성 API의 응답 구조 정의
  * 작성자: 이승주
  * 생성일: 2025-07-10
- * 수정일: 2025-07-20
+ * 수정일: 2025-07-24
  */
 package com.umc.tomorrow.domain.careertalk.dto.response;
 
@@ -13,8 +13,8 @@ import lombok.Getter;
 
 @Getter
 @Builder
-@Schema(description = "커리어톡 게시글 생성 응답 DTO")
-public class CreateCareertalkResponseDto {
+@Schema(description = "커리어톡 게시글 응답 DTO") //생성,수정,삭제 요청 시 응답 Dto
+public class CareertalkResponseDto {
 
     @Schema(description = "커리어톡 게시글 ID", example = "1")
     private Long id;

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/entity/Careertalk.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/entity/Careertalk.java
@@ -52,4 +52,11 @@ public class Careertalk extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    public void update(String title, String content, String category) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
+
+
 }

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/exception/CareertalkException.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/exception/CareertalkException.java
@@ -1,3 +1,8 @@
+/**
+ * 커리어톡 에 대한 예외처리 클래스
+ * 작성자: 이승주
+ * 생성일: 2025-07-24
+ */
 package com.umc.tomorrow.domain.careertalk.exception;
 
 import com.umc.tomorrow.domain.careertalk.exception.code.CareertalkStatus;

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/exception/CareertalkException.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/exception/CareertalkException.java
@@ -1,0 +1,11 @@
+package com.umc.tomorrow.domain.careertalk.exception;
+
+import com.umc.tomorrow.domain.careertalk.exception.code.CareertalkStatus;
+import com.umc.tomorrow.global.common.exception.RestApiException;
+
+public class CareertalkException extends RestApiException {
+
+    public CareertalkException(CareertalkStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/exception/code/CareertalkStatus.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/exception/code/CareertalkStatus.java
@@ -1,3 +1,8 @@
+/**
+ * 커리어톡 에 대한 예외처리 상태코드
+ * 작성자: 이승주
+ * 생성일: 2025-07-24
+ */
 package com.umc.tomorrow.domain.careertalk.exception.code;
 
 import com.umc.tomorrow.global.common.exception.code.BaseCode;

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/exception/code/CareertalkStatus.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/exception/code/CareertalkStatus.java
@@ -1,0 +1,31 @@
+package com.umc.tomorrow.domain.careertalk.exception.code;
+
+import com.umc.tomorrow.global.common.exception.code.BaseCode;
+import com.umc.tomorrow.global.common.exception.code.BaseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CareertalkStatus implements BaseCodeInterface {
+
+    CAREERTALK_NOT_FOUND(HttpStatus.NOT_FOUND, "CAREERTALK404", "해당 커리어톡 게시글을 찾을 수 없습니다."),
+    CAREERTALK_FORBIDDEN(HttpStatus.FORBIDDEN, "CAREERTALK403", "해당 커리어톡 게시글에 대한 권한이 없습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess = false;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCode getCode() {
+        return BaseCode.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/repository/CareertalkRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/repository/CareertalkRepository.java
@@ -11,11 +11,17 @@ import com.umc.tomorrow.domain.careertalk.entity.Careertalk;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CareertalkRepository extends JpaRepository<Careertalk, Long> {
-    // 첫 요청 (cursor 없음)
-    Slice<Careertalk> findAllByOrderByIdDesc(Pageable pageable);
 
-    // 커서 기반 요청
+    Slice<Careertalk> findAllByOrderByIdDesc(Pageable pageable);
     Slice<Careertalk> findByIdLessThanOrderByIdDesc(Long id, Pageable pageable);
+
+    Slice<Careertalk> findByTitleContainingIgnoreCaseOrderByIdDesc(String title, Pageable pageable);
+    Slice<Careertalk> findByTitleContainingIgnoreCaseAndIdLessThanOrderByIdDesc(String title, Long id, Pageable pageable);
+
+    Slice<Careertalk> findByCategoryOrderByIdDesc(String category, Pageable pageable);
+    Slice<Careertalk> findByCategoryAndIdLessThanOrderByIdDesc(String category, Long id, Pageable pageable);
 }

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/service/command/CareertalkCommandService.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/service/command/CareertalkCommandService.java
@@ -7,9 +7,13 @@
 package com.umc.tomorrow.domain.careertalk.service.command;
 
 import com.umc.tomorrow.domain.careertalk.dto.request.CreateCareertalkRequestDto;
-import com.umc.tomorrow.domain.careertalk.dto.response.CreateCareertalkResponseDto;
+import com.umc.tomorrow.domain.careertalk.dto.request.UpdateCareertalkRequestDto;
+import com.umc.tomorrow.domain.careertalk.dto.response.CareertalkResponseDto;
 
 public interface CareertalkCommandService {
 
-    CreateCareertalkResponseDto createCareertalk(String username, CreateCareertalkRequestDto createCareertalkRequestDto);
+    CareertalkResponseDto createCareertalk(Long userId, CreateCareertalkRequestDto createCareertalkRequestDto);
+    CareertalkResponseDto updateCareertalk(Long userId, Long careertalkId, UpdateCareertalkRequestDto updateCareertalkRequestDto);
+    CareertalkResponseDto deleteCareertalk(Long userId, Long careertalkId);
+
 }

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryService.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryService.java
@@ -10,6 +10,9 @@ import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkListResponse
 import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkResponseDto;
 
 public interface CareertalkQueryService {
-    GetCareertalkListResponseDto getCareertalks(Long cursor, int size);
     GetCareertalkResponseDto getCareertalk(Long id);
+    GetCareertalkListResponseDto getCareertalks(Long cursor, int size);
+    GetCareertalkListResponseDto getCareertalksByTitle(String title, Long cursor, int size);
+    GetCareertalkListResponseDto getCareertalksByCategory(String category, Long cursor, int size);
 }
+

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryServiceImpl.java
@@ -1,13 +1,19 @@
+/**
+ * 커리어톡 조회 서비스
+ * - 커리어톡 조회 비즈니스 로직
+ * 작성자: 이승주
+ * 생성일: 2020-07-10
+ * 수정일: 2025-07-24
+ */
 package com.umc.tomorrow.domain.careertalk.service.query;
 
 import com.umc.tomorrow.domain.careertalk.converter.CareertalkConverter;
 import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkResponseDto;
 import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkListResponseDto;
 import com.umc.tomorrow.domain.careertalk.entity.Careertalk;
+import com.umc.tomorrow.domain.careertalk.exception.CareertalkException;
+import com.umc.tomorrow.domain.careertalk.exception.code.CareertalkStatus;
 import com.umc.tomorrow.domain.careertalk.repository.CareertalkRepository;
-import com.umc.tomorrow.global.common.exception.RestApiException;
-import com.umc.tomorrow.global.common.exception.code.GlobalErrorStatus;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -20,7 +26,6 @@ import java.util.List;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class CareertalkQueryServiceImpl implements CareertalkQueryService {
 
@@ -28,8 +33,9 @@ public class CareertalkQueryServiceImpl implements CareertalkQueryService {
 
     /**
      * 커리어톡 게시글 목록 조회
+     *
      * @param cursor 이전 요청에서의 마지막 게시글 번호
-     * @param size 요청할 게시글 개수
+     * @param size   요청할 게시글 개수
      * @return 게시글 목록 DTO
      */
     @Override
@@ -58,14 +64,15 @@ public class CareertalkQueryServiceImpl implements CareertalkQueryService {
 
     /**
      * 커리어톡 게시글 상세 조회
+     *
      * @param careertalkId 조회하고자 하는 커리어톡 게시글 Id
      * @return 해당 게시글 DTO
      */
 
     @Override
-    public GetCareertalkResponseDto getCareertalk(Long careertalkId){
+    public GetCareertalkResponseDto getCareertalk(Long careertalkId) {
         Careertalk careertalk = careertalkRepository.findById(careertalkId)
-                .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
+                .orElseThrow(() -> new CareertalkException(CareertalkStatus.CAREERTALK_NOT_FOUND));
 
         return GetCareertalkResponseDto.builder()
                 .id(careertalk.getId())
@@ -73,6 +80,63 @@ public class CareertalkQueryServiceImpl implements CareertalkQueryService {
                 .title(careertalk.getTitle())
                 .content(careertalk.getContent())
                 .createdAt(careertalk.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * 커리어톡 제목으로 게시글 조회
+     * @param title 커리어톡 게시글 제목
+     * @param cursor 마지막으로 조회한 게시글 id
+     * @param size 한 페이지에 보여질 사이즈
+     * @return 커리어톡 게시글 목록 DTO
+     */
+    @Override
+    public GetCareertalkListResponseDto getCareertalksByTitle(String title, Long cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Careertalk> slice;
+
+        if (cursor == null) {
+            slice = careertalkRepository.findByTitleContainingIgnoreCaseOrderByIdDesc(title, pageable);
+        } else {
+            slice = careertalkRepository.findByTitleContainingIgnoreCaseAndIdLessThanOrderByIdDesc(title, cursor,
+                    pageable);
+        }
+
+        List<GetCareertalkResponseDto> dtoList = slice.getContent().stream()
+                .map(CareertalkConverter::toGetCareertalkResponseDto)
+                .toList();
+
+        return GetCareertalkListResponseDto.builder()
+                .careertalkList(dtoList)
+                .hasNext(slice.hasNext())
+                .build();
+    }
+
+    /**
+     * 커리어톡 카테고리로 검색
+     * @param category 커리어톡 게시글 카테고리
+     * @param cursor 마지막으로 조회한 게시글 id
+     * @param size 한 페이지에 보여질 사이즈
+     * @return 커리어톡 게시글 목록 DTO
+     */
+    @Override
+    public GetCareertalkListResponseDto getCareertalksByCategory(String category, Long cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Careertalk> slice;
+
+        if (cursor == null) {
+            slice = careertalkRepository.findByCategoryOrderByIdDesc(category, pageable);
+        } else {
+            slice = careertalkRepository.findByCategoryAndIdLessThanOrderByIdDesc(category, cursor, pageable);
+        }
+
+        List<GetCareertalkResponseDto> dtoList = slice.getContent().stream()
+                .map(CareertalkConverter::toGetCareertalkResponseDto)
+                .toList();
+
+        return GetCareertalkListResponseDto.builder()
+                .careertalkList(dtoList)
+                .hasNext(slice.hasNext())
                 .build();
     }
 }

--- a/src/main/resources/validation.properties
+++ b/src/main/resources/validation.properties
@@ -26,6 +26,9 @@ review.user.notnull=작성자는 필수입니다.
 careertalk.category.notblank=카테고리 선택은 필수입니다.
 careertalk.title.notblank=제목은 필수입니다.
 careertalk.content.notblank=내용은 필수입니다.
+careertalk.category.size=카테코리는 20자 이내입니다.
+careertalk.title.size=제목은 50자 이내입니다.
+
 
 # application - ??? ??
 application.status.notblank="??? ?????."


### PR DESCRIPTION
## 관련 이슈
- close #44

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 커리어톡 컨트롤러 API 추가
- 커리어톡 쿼리 서비스의 메서드 추가
- 커리어톡 레포지토리 구현
- swagger를 이용한 API 테스트

## 리뷰 포인트
- 리뷰 포인트는 없고, 추후에 커리어톡 카테고리를 ENUM으로 변경하고, 카테고리 유효성 검사 로직으로 리팩토링하겠습니다!

## 🖼스크린샷 (선택)
<img width="789" height="862" alt="스크린샷 2025-07-24 오전 3 28 15" src="https://github.com/user-attachments/assets/9fac6853-5d70-47a7-ae16-63b26f784fad" />
<img width="685" height="860" alt="스크린샷 2025-07-24 오전 3 48 27" src="https://github.com/user-attachments/assets/9e9b3571-19d2-4b43-aea9-22e976e0156a" />

