### PR TITLE
Feat/지원자 이력서 조회 API 구현 및 테스트 연동

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/controller/ApplicationController.java
@@ -8,6 +8,7 @@
 package com.umc.tomorrow.domain.application.controller;
 
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
 import com.umc.tomorrow.domain.application.service.command.ApplicationService;
 import com.umc.tomorrow.global.common.base.BaseResponse;
@@ -48,6 +49,26 @@ public class ApplicationController {
                 postId, applicationId, requestDTO
         );
         
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+    }
+
+    @Operation(
+            summary = "개별 지원자 이력서 조회",
+            description = "특정 공고에 지원한 개별 지원자의 이력서 정보를 조회합니다."
+    )
+    @GetMapping("/{postId}/applicants/{applicantId}/resume")
+    public ResponseEntity<BaseResponse<ApplicationDetailsResponseDTO>> getApplicantResume(
+            @Parameter(description = "공고 ID", example = "301")
+            @PathVariable @Min(1) Long postId,
+
+            @Parameter(description = "지원자 ID", example = "101")
+            @PathVariable @Min(1) Long applicantId
+    ) {
+        // 여기서는 Path Variable만 사용하여 조회하도록 구현
+        ApplicationDetailsResponseDTO result = applicationService.getApplicantResume(
+                postId,
+                applicantId
+        );
         return ResponseEntity.ok(BaseResponse.onSuccess(result));
     }
 } 

--- a/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
@@ -7,8 +7,19 @@
 package com.umc.tomorrow.domain.application.converter;
 
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
+import com.umc.tomorrow.domain.application.entity.Application;
 import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
+import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.resume.entity.Certificate;
+import com.umc.tomorrow.domain.resume.entity.Experience;
+import com.umc.tomorrow.domain.resume.entity.Resume;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class ApplicationConverter {
 
@@ -26,6 +37,71 @@ public class ApplicationConverter {
         return UpdateApplicationStatusResponseDTO.builder()
                 .applicationId(applicationId)
                 .status(status.getLabel())
+                .build();
+    }
+
+    // 엔티티들을 ApplicantResumeResponseDTO로 변환하는 메서드
+    public static ApplicationDetailsResponseDTO toApplicantResumeResponseDTO(
+            Application application,
+            User user,
+            Resume resume
+    ) {
+        String statusText = application.getStatus() == null
+                ? "미정"
+                : application.getStatus().getLabel();
+
+        // 1. 사용자 프로필 정보 DTO 생성
+        ApplicationDetailsResponseDTO.UserProfileDTO userProfile = ApplicationDetailsResponseDTO.UserProfileDTO.builder()
+                .userName(user.getName())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .build();
+
+        // 2. 이력서 상세 정보 DTO 생성
+        ApplicationDetailsResponseDTO.ResumeInfoDTO resumeInfo = null;
+        if (resume != null) {
+            List<ApplicationDetailsResponseDTO.ExperienceDTO> experienceDTOS = Optional.ofNullable(resume.getExperiences())
+                    .orElse(Collections.emptyList())
+                    .stream()
+                    .map(ApplicationConverter::toExperienceDTO)
+                    .collect(Collectors.toList());
+
+            List<ApplicationDetailsResponseDTO.CertificationDTO> certificationDTOS = Optional.ofNullable(resume.getCertificates())
+                    .orElse(Collections.emptyList())
+                    .stream()
+                    .map(ApplicationConverter::toCertificationDTO)
+                    .collect(Collectors.toList());
+
+            resumeInfo = ApplicationDetailsResponseDTO.ResumeInfoDTO.builder()
+                    .resumeContent(resume.getIntroduction()) // Resume 엔티티의 introduction 필드사용
+                    .experiences(experienceDTOS)
+                    .certifications(certificationDTOS)
+                    .build();
+        }
+
+        // 3. 최종 응답 DTO 생성 및 반환
+        return ApplicationDetailsResponseDTO.builder()
+                .applicantId(user.getId())
+                .status(statusText)
+                .userProfile(userProfile)
+                .resumeInfo(resumeInfo)
+                .build();
+    }
+
+    // Experience 엔티티를 ExperienceDTO로 변환
+    private static ApplicationDetailsResponseDTO.ExperienceDTO toExperienceDTO(Experience experience) {
+        return ApplicationDetailsResponseDTO.ExperienceDTO.builder()
+                .id(experience.getId())
+                .company(experience.getPlace())
+                .position(experience.getTask())
+                .duration(experience.getDuration().getLabel()) // Enum → Label
+                .description(experience.getDescription())
+                .build();
+    }
+
+    // Certificate 엔티티를 CertificationDTO로 변환
+    private static ApplicationDetailsResponseDTO.CertificationDTO toCertificationDTO(Certificate certificate) {
+        return ApplicationDetailsResponseDTO.CertificationDTO.builder()
                 .build();
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicationDetailsResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicationDetailsResponseDTO.java
@@ -1,0 +1,72 @@
+/**
+ * 개별 지원자 이력서 조회 응답 DTO
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-24
+ */
+package com.umc.tomorrow.domain.application.dto.response;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApplicationDetailsResponseDTO {
+    private Long applicantId;
+    private String status; // 현재 지원 상태
+
+    private UserProfileDTO userProfile;
+    private ResumeInfoDTO resumeInfo;
+
+    // 사용자 프로필 일부 가져옴
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserProfileDTO {
+        private String userName;
+        private String email;
+        private String phoneNumber;
+        private String profileImageUrl;
+    }
+
+    // 자기소개 정보 가져옴
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResumeInfoDTO {
+        private String resumeContent;
+        private String portfolioUrl;
+        private List<ExperienceDTO> experiences;
+        private List<CertificationDTO> certifications;
+    }
+
+    // 경험
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExperienceDTO {
+        private Long id;
+        private String company;     // 일한 곳
+        private String position;    // 했던 일
+        private String duration;    // "1년~2년" 등 라벨값
+        private String description; // 상세 설명
+    }
+
+    // 자격증
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CertificationDTO {
+        private String certificationName;
+        private String fileUrl;
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/application/entity/Application.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/entity/Application.java
@@ -11,6 +11,7 @@ package com.umc.tomorrow.domain.application.entity;
 import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
 import com.umc.tomorrow.domain.job.entity.Job;
 import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.resume.entity.Resume;
 import com.umc.tomorrow.domain.review.entity.Review;
 import com.umc.tomorrow.global.common.base.BaseEntity;
 import jakarta.persistence.*;
@@ -51,6 +52,10 @@ public class Application extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime appliedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id") // DB 컬럼명
+    private Resume resume;
 
     /**
      * 합격/불합격 상태 업데이트

--- a/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
@@ -9,6 +9,7 @@ package com.umc.tomorrow.domain.application.service.command;
 
 import com.umc.tomorrow.domain.application.converter.ApplicationConverter;
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
 import com.umc.tomorrow.domain.application.entity.Application;
 import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
@@ -17,6 +18,8 @@ import com.umc.tomorrow.domain.application.repository.ApplicationRepository;
 import com.umc.tomorrow.domain.job.entity.Job;
 import com.umc.tomorrow.domain.job.exception.JobErrorStatus;
 import com.umc.tomorrow.domain.job.repository.JobRepository;
+import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.resume.entity.Resume;
 import com.umc.tomorrow.global.common.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -61,4 +64,27 @@ public class ApplicationService {
                 .status(requestDTO.getStatus())
                 .build();
     }
+
+    /**
+     * 개별 지원자 이력서 조회
+     */
+    public ApplicationDetailsResponseDTO getApplicantResume(Long postId, Long applicantId) {
+        // 1. 공고 ID와 지원자 ID로 지원서(Application)를 조회
+        Application application = applicationRepository.findByJobIdAndUserId(postId, applicantId)
+                .orElseThrow(() -> new RestApiException(ApplicationErrorStatus.APPLICATION_NOT_FOUND));
+
+        // 2. 연관된 엔티티들 조회
+        User user = application.getUser();
+
+        // Application 엔티티에 추가된 `resume` 필드를 사용하여 조회
+        Resume resume = application.getResume();
+
+        // 3. Converter를 사용하여 엔티티를 DTO로 변환
+        return ApplicationConverter.toApplicantResumeResponseDTO(
+                application,
+                user,
+                resume
+        );
+    }
+
 } 

--- a/src/main/java/com/umc/tomorrow/domain/resume/converter/ResumeConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/resume/converter/ResumeConverter.java
@@ -12,6 +12,8 @@ import com.umc.tomorrow.domain.resume.entity.Resume;
 import com.umc.tomorrow.domain.resume.entity.Experience;
 import com.umc.tomorrow.domain.resume.entity.Certificate;
 import com.umc.tomorrow.domain.member.entity.User;
+import com.umc.tomorrow.domain.resume.enums.ExperienceDuration;
+
 import java.util.stream.Collectors;
 import java.util.List;
 
@@ -29,7 +31,7 @@ public class ResumeConverter {
                 .place(expDto.getPlace())
                 .task(expDto.getTask())
                 .year(expDto.getYear())
-                .duration(expDto.getDuration())
+                .duration(ExperienceDuration.valueOf(expDto.getDuration()))
                 .resume(resume)
                 .build())
             .collect(Collectors.toList());
@@ -52,7 +54,7 @@ public class ResumeConverter {
                     .place(exp.getPlace())
                     .task(exp.getTask())
                     .year(exp.getYear())
-                    .duration(exp.getDuration())
+                    .duration(String.valueOf(exp.getDuration()))
                     .build())
                 .collect(Collectors.toList()))
             .certificates(resume.getCertificates().stream()

--- a/src/main/java/com/umc/tomorrow/domain/resume/entity/Experience.java
+++ b/src/main/java/com/umc/tomorrow/domain/resume/entity/Experience.java
@@ -6,6 +6,7 @@
  */
 package com.umc.tomorrow.domain.resume.entity;
 
+import com.umc.tomorrow.domain.resume.enums.ExperienceDuration;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
@@ -22,15 +23,15 @@ public class Experience {
 
     private String place;
     private String task;
-    private String duration;
+
+    @Enumerated(EnumType.STRING)
+    private ExperienceDuration duration;
+
     private int year;
+    private String description; // 상세 설명(선택)
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Resume resume;
-
-    public void setYear(int year) {
-        this.year = year;
-    }
 
     public int getYear() {
         return year;

--- a/src/main/java/com/umc/tomorrow/domain/resume/enums/ExperienceDuration.java
+++ b/src/main/java/com/umc/tomorrow/domain/resume/enums/ExperienceDuration.java
@@ -1,0 +1,26 @@
+package com.umc.tomorrow.domain.resume.enums;
+import lombok.Getter;
+
+@Getter
+public enum ExperienceDuration {
+    SHORT("단기"),
+    UNDER_3M("3개월 이하"),
+    UNDER_6M("6개월 이하"),
+    M6_TO_1Y("6개월~1년"),
+    Y1_TO_2Y("1년~2년"),
+    Y2_TO_3Y("2년~3년"),
+    OVER_3Y("3년 이상");
+
+    private final String label;
+
+    ExperienceDuration(String label) {
+        this.label = label;
+    }
+
+    public static ExperienceDuration from(String label) {
+        for (ExperienceDuration d : values()) {
+            if (d.getLabel().equals(label)) return d;
+        }
+        throw new IllegalArgumentException("올바르지 않은 경력 기간입니다.");
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #이슈번호

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 공고 ID, 지원자 ID 기반 지원서 및 이력서 정보 조회 기능 구현
- 지원 상태(status) enum → 문자열 변환 로직 개선

related to #38

## 리뷰 포인트
- UserProfileDTO, ResumeInfoDTO, ExperienceDTO 등은 ApplicationDetailsResponseDTO 안에 넣었습니다.

## 🖼스크린샷 (선택)
- swagger 테스트 캡쳐본입니다. (get /api/v1/posts/{postId}/applicants/{applicantId}/resume)
<img width="1165" height="796" alt="image" src="https://github.com/user-attachments/assets/e7c156db-db7a-4d4a-a715-a443dd3355be" />
