### PR TITLE
feat/지원서 전체/합격자 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/controller/ApplicationController.java
@@ -8,11 +8,13 @@
 package com.umc.tomorrow.domain.application.controller;
 
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
 import com.umc.tomorrow.domain.application.service.command.ApplicationService;
 import com.umc.tomorrow.global.common.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -20,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Validated
 @Tag(name = "Application", description = "지원서 관련 API")

--- a/src/main/java/com/umc/tomorrow/domain/application/controller/query/ApplicationQueryController.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/controller/query/ApplicationQueryController.java
@@ -1,0 +1,43 @@
+/**
+ * 지원서 조회 컨트롤러
+ * - 로그인한 사용자의 지원서 목록 조회 (전체 / 합격만)
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-24
+ */
+package com.umc.tomorrow.domain.application.controller.query;
+
+import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
+import com.umc.tomorrow.domain.application.service.query.ApplicationQueryService;
+import com.umc.tomorrow.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Application", description = "지원서 관련 API")
+@RequestMapping("/api/v1/applications")
+public class ApplicationQueryController {
+
+    private final ApplicationQueryService applicationQueryService;
+
+    @Operation(
+            summary = "지원 현황 목록 조회",
+            description = "`type=all`이면 전체, `type=pass`이면 합격한 지원만 필터링합니다."
+    )
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<ApplicationStatusListResponseDTO>>> getApplications(
+            @RequestParam(defaultValue = "all") String type,
+            @AuthenticationPrincipal(expression = "user.id") Long userId
+    ) {
+        List<ApplicationStatusListResponseDTO> result = applicationQueryService.getApplicationsByType(userId, type);
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
@@ -7,7 +7,9 @@
 package com.umc.tomorrow.domain.application.converter;
 
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
+import com.umc.tomorrow.domain.application.entity.Application;
 import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
 
 public class ApplicationConverter {
@@ -16,7 +18,7 @@ public class ApplicationConverter {
      * 요청 DTO → Enum
      */
     public static ApplicationStatus toEnum(UpdateApplicationStatusRequestDTO dto) {
-        return ApplicationStatus.from(dto.getStatus());
+        return ApplicationStatus.from(String.valueOf(dto.getStatus()));
     }
 
     /**
@@ -25,7 +27,22 @@ public class ApplicationConverter {
     public static UpdateApplicationStatusResponseDTO toResponse(Long applicationId, ApplicationStatus status) {
         return UpdateApplicationStatusResponseDTO.builder()
                 .applicationId(applicationId)
-                .status(status.getLabel())
+                .status(status)
+                .build();
+    }
+
+    /**
+    * Application 엔티티를 지원 현황 리스트 응답 DTO로 변환하는 메서드
+    *
+    * @param application 변환 대상 Application 엔티티
+    * @return ApplicationStatusListResponseDTO - 지원 현황에 필요한 요약 정보
+    */
+    public static ApplicationStatusListResponseDTO toStatusListDTO(Application application) {
+        return ApplicationStatusListResponseDTO.builder()
+                .postTitle(application.getJob().getTitle())
+                .company(application.getJob().getCompanyName()) // Job에 필드가 있어야 함
+                .date(application.getAppliedAt().toLocalDate().toString()) // LocalDateTime → yyyy-MM-dd
+                .status(application.getStatus() == null ? ApplicationStatus.valueOf("미정") : application.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/application/dto/request/UpdateApplicationStatusRequestDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/dto/request/UpdateApplicationStatusRequestDTO.java
@@ -7,6 +7,7 @@
  */
 package com.umc.tomorrow.domain.application.dto.request;
 
+import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -17,5 +18,5 @@ import lombok.Getter;
 public class UpdateApplicationStatusRequestDTO {
     
     @NotBlank(message = "{application.status.notblank}")
-    private String status;
+    private ApplicationStatus status;
 } 

--- a/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicationStatusListResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicationStatusListResponseDTO.java
@@ -3,7 +3,7 @@
  * - 지원자 합격/불합격 처리 응답
  *
  * 작성자: 정여진
- * 생성일: 2025-07-16
+ * 생성일: 2025-07-24
  */
 package com.umc.tomorrow.domain.application.dto.response;
 
@@ -14,10 +14,11 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class UpdateApplicationStatusResponseDTO {
-    
-    private Long applicationId;
+public class ApplicationStatusListResponseDTO {
+    private String postTitle;
+    private String company;
+    private String date;
 
     @NotBlank(message = "{application.status.notblank}")
     private ApplicationStatus status; // "합격", "불합격" (default = 불합격)
-} 
+}

--- a/src/main/java/com/umc/tomorrow/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/repository/ApplicationRepository.java
@@ -8,6 +8,7 @@
 package com.umc.tomorrow.domain.application.repository;
 
 import com.umc.tomorrow.domain.application.entity.Application;
+import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -40,4 +41,14 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
      */
     @Query("SELECT a FROM Application a WHERE a.job.id = :jobId AND a.status = :status")
     List<Application> findByJobIdAndStatus(@Param("jobId") Long jobId, @Param("status") Boolean status);
-} 
+
+    /**
+     * 사용자의 ID에 따라 공고 조회 (전체)
+     */
+    List<Application> findAllByUserId(Long userId);
+
+    /**
+     * 사용자의 ID, 상태(합격/불합)에 따라 공고 조회
+     */
+    List<Application> findAllByUserIdAndStatus(Long userId, ApplicationStatus status);
+}

--- a/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
@@ -9,6 +9,7 @@ package com.umc.tomorrow.domain.application.service.command;
 
 import com.umc.tomorrow.domain.application.converter.ApplicationConverter;
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
 import com.umc.tomorrow.domain.application.entity.Application;
 import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
@@ -21,6 +22,9 @@ import com.umc.tomorrow.global.common.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/tomorrow/domain/application/service/query/ApplicationQueryService.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/service/query/ApplicationQueryService.java
@@ -1,0 +1,50 @@
+/**
+ * ApplicationQueryService
+ * - 사용자별 지원 현황(전체/합격) 조회 비즈니스 로직 담당
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-24
+ */
+package com.umc.tomorrow.domain.application.service.query;
+
+import com.umc.tomorrow.domain.application.converter.ApplicationConverter;
+import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
+import com.umc.tomorrow.domain.application.entity.Application;
+import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
+import com.umc.tomorrow.domain.application.repository.ApplicationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationQueryService {
+
+    private final ApplicationRepository applicationRepository;
+
+    /**
+     * 지원 현황 목록을 조회합니다.
+     *
+     * @param userId 로그인한 사용자 ID
+     * @param type "all"이면 전체, "pass"이면 합격된 항목만 조회
+     * @return 지원서 요약 정보 리스트
+     */
+    public List<ApplicationStatusListResponseDTO> getApplicationsByType(Long userId, String type) {
+        List<Application> applications;
+
+        if ("pass".equalsIgnoreCase(type)) {
+            // 사용자의 합격된 지원서만 조회
+            applications = applicationRepository.findAllByUserIdAndStatus(userId, ApplicationStatus.ACCEPTED);
+        } else {
+            // 사용자의 전체 지원서 조회
+            applications = applicationRepository.findAllByUserId(userId);
+        }
+
+        // 지원서 목록을 응답 DTO로 (converter 이용)
+        return applications.stream()
+                .map(ApplicationConverter::toStatusListDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/auth/security/CustomOAuth2User.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/security/CustomOAuth2User.java
@@ -53,4 +53,8 @@ public class CustomOAuth2User implements OAuth2User {
     public String getUsername() {
         return userDTO.getUsername();
     }
+
+    public UserDTO getUser() {
+        return this.userDTO;
+    }
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
@@ -34,7 +34,6 @@ public class Job extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-
     @Column(nullable = false, length = 100)
     private String title;
 


### PR DESCRIPTION
## 관련 이슈
- close #이슈번호

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- GET /api/v1/applications?type=all: 사용자의 전체 지원 내역 조회
- GET /api/v1/applications?type=pass: 사용자의 합격 지원 내역 조회
- ApplicationQueryController, ApplicationQueryService 추가
- ApplicationStatusListResponseDTO, ApplicationConverter 구현
- ApplicationStatus enum 활용

related to #48

## 리뷰 포인트
- 리뷰어가 확인해주면 좋을 부분이 있다면 작성해 주세요.

## 🖼스크린샷 (선택)
swagger 캡쳐본입니다. (get /api/v1/applications?type=all, /api/v1/applications?type=pass)
<img width="767" height="731" alt="image" src="https://github.com/user-attachments/assets/ba5a52c1-eb0b-460e-8ef4-0baeaabc0b84" />
