### PR TITLE
feat: 내가 등록한 공고 조회 API 구현 및 관련 DTO 추가

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
@@ -12,6 +12,7 @@ import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsRespon
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
 import com.umc.tomorrow.domain.application.entity.Application;
 import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
+import com.umc.tomorrow.domain.career.entity.Career;
 import com.umc.tomorrow.domain.member.entity.User;
 import com.umc.tomorrow.domain.resume.entity.Certificate;
 import com.umc.tomorrow.domain.resume.entity.Experience;
@@ -76,11 +77,12 @@ public class ApplicationConverter {
         // 2. 이력서 상세 정보 DTO 생성
         ApplicationDetailsResponseDTO.ResumeInfoDTO resumeInfo = null;
         if (resume != null) {
-            List<ApplicationDetailsResponseDTO.ExperienceDTO> experienceDTOS = Optional.ofNullable(resume.getExperiences())
-                    .orElse(Collections.emptyList())
-                    .stream()
-                    .map(ApplicationConverter::toExperienceDTO)
-                    .collect(Collectors.toList());
+            List<ApplicationDetailsResponseDTO.ExperienceDTO> experienceDTOS =
+                    Optional.ofNullable(resume.getCareer()) //
+                            .orElse(Collections.emptyList())
+                            .stream()
+                            .map(ApplicationConverter::toExperienceDTO)
+                            .collect(Collectors.toList());
 
             List<ApplicationDetailsResponseDTO.CertificationDTO> certificationDTOS = Optional.ofNullable(resume.getCertificates())
                     .orElse(Collections.emptyList())
@@ -111,14 +113,23 @@ public class ApplicationConverter {
                 .id(experience.getId())
                 .company(experience.getPlace())
                 .position(experience.getTask())
-                .duration(experience.getDuration().getLabel()) // Enum → Label
-                .description(experience.getDescription())
+                .duration(experience.getDuration()) // Enum → Label
+                .description(String.valueOf(experience))
                 .build();
     }
 
     // Certificate 엔티티를 CertificationDTO로 변환
     private static ApplicationDetailsResponseDTO.CertificationDTO toCertificationDTO(Certificate certificate) {
         return ApplicationDetailsResponseDTO.CertificationDTO.builder()
+                .build();
+    }
+
+    private static ApplicationDetailsResponseDTO.ExperienceDTO toExperienceDTO(Career career) {
+        return ApplicationDetailsResponseDTO.ExperienceDTO.builder()
+                .id(career.getId())
+                .company(career.getCompany())
+                .duration(career.getWorkedPeriod().getLabel()) // Enum이므로 label 추출 메서드 필요
+                .description(career.getDescription())
                 .build();
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
@@ -10,8 +10,6 @@ package com.umc.tomorrow.domain.application.service.command;
 import com.umc.tomorrow.domain.application.converter.ApplicationConverter;
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
 
-import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
-
 import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsResponseDTO;
 
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
@@ -20,7 +18,7 @@ import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
 import com.umc.tomorrow.domain.application.exception.ApplicationErrorStatus;
 import com.umc.tomorrow.domain.application.repository.ApplicationRepository;
 import com.umc.tomorrow.domain.job.entity.Job;
-import com.umc.tomorrow.domain.job.exception.JobErrorStatus;
+import com.umc.tomorrow.domain.job.exception.code.JobErrorStatus;
 import com.umc.tomorrow.domain.job.repository.JobRepository;
 import com.umc.tomorrow.domain.member.entity.User;
 import com.umc.tomorrow.domain.resume.entity.Resume;
@@ -28,9 +26,6 @@ import com.umc.tomorrow.global.common.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/tomorrow/domain/career/enums/WorkPeriodType.java
+++ b/src/main/java/com/umc/tomorrow/domain/career/enums/WorkPeriodType.java
@@ -1,11 +1,21 @@
 package com.umc.tomorrow.domain.career.enums;
 
 public enum WorkPeriodType {
-    SHORT_TERM, //단기
-    LESS_THAN_3_MONTHS, //3개월 이하
-    LESS_THAN_6_MONTHS, // 6개월 이하
-    SIX_TO_TWELVE_MONTHS, // 6개월~1년 이하
-    ONE_TO_TWO_YEARS, //1~2년
-    TWO_TO_THREE_YEARS, //2~3년
-    MORE_THAN_THREE_YEARS; //3년 이상
+    SHORT_TERM("단기"),
+    LESS_THAN_3_MONTHS("3개월 이하"),
+    LESS_THAN_6_MONTHS("6개월 이하"),
+    SIX_TO_TWELVE_MONTHS("6개월~1년 이하"),
+    ONE_TO_TWO_YEARS("1~2년"),
+    TWO_TO_THREE_YEARS("2~3년"),
+    MORE_THAN_THREE_YEARS("3년 이상");
+
+    private final String label;
+
+    WorkPeriodType(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/controller/command/JobCommandController.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/controller/command/JobCommandController.java
@@ -1,4 +1,4 @@
-package com.umc.tomorrow.domain.job.controller;
+package com.umc.tomorrow.domain.job.controller.command;
 
 import com.umc.tomorrow.domain.job.dto.request.BusinessRequestDTO;
 import com.umc.tomorrow.domain.job.dto.request.JobRequestDTO;
@@ -6,7 +6,6 @@ import com.umc.tomorrow.domain.job.dto.request.PersonalRequestDTO;
 import com.umc.tomorrow.domain.job.dto.response.JobStepResponseDTO;
 import com.umc.tomorrow.domain.job.service.command.JobCommandService;
 import com.umc.tomorrow.domain.member.entity.User;
-import com.umc.tomorrow.domain.member.repository.UserRepository;
 import com.umc.tomorrow.global.common.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryController.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryController.java
@@ -1,0 +1,43 @@
+package com.umc.tomorrow.domain.job.controller.query;
+
+import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
+import com.umc.tomorrow.domain.job.dto.request.MyPostResponseDTO;
+import com.umc.tomorrow.domain.job.service.query.JobQueryService;
+import com.umc.tomorrow.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/my-posts")
+@RequiredArgsConstructor
+@Tag(name = "MyPosts", description = "내가 작성한 공고 조회 API")
+public class JobQueryController {
+
+    private final JobQueryService jobQueryService;
+
+    @Operation(summary = "내 모집중 공고 조회", description = "사용자가 작성한 모집중인 공고를 조회합니다.")
+    @GetMapping("/open")
+    public ResponseEntity<BaseResponse<List<MyPostResponseDTO>>> getOpenPosts(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        List<MyPostResponseDTO> result = jobQueryService.getMyPosts(user.getUserDTO().getId(), "open");
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+    }
+
+    @Operation(summary = "내 모집완료 공고 조회", description = "사용자가 작성한 모집완료된 공고를 조회합니다.")
+    @GetMapping("/closed")
+    public ResponseEntity<BaseResponse<List<MyPostResponseDTO>>> getClosedPosts(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        List<MyPostResponseDTO> result = jobQueryService.getMyPosts(user.getUserDTO().getId(), "closed");
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryServiceImpl.java
@@ -1,0 +1,45 @@
+/**
+ * 내 공고 조회 서비스 구현체
+ * 작성자: 정인도
+ * 생성일: 2025-07-25
+ */
+package com.umc.tomorrow.domain.job.controller.query;
+
+import com.umc.tomorrow.domain.job.converter.JobConverter;
+import com.umc.tomorrow.domain.job.dto.request.MyPostResponseDTO;
+import com.umc.tomorrow.domain.job.entity.Job;
+import com.umc.tomorrow.domain.job.enums.PostStatus;
+import com.umc.tomorrow.domain.job.exception.JobException;
+import com.umc.tomorrow.domain.job.repository.JobRepository;
+import com.umc.tomorrow.domain.job.service.query.JobQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.umc.tomorrow.domain.job.exception.code.JobErrorStatus;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class JobQueryServiceImpl implements JobQueryService {
+
+    private final JobRepository jobRepository;
+    private final JobConverter jobConverter;
+
+    @Override
+    public List<MyPostResponseDTO> getMyPosts(Long userId, String status) {
+        PostStatus postStatus;
+
+        try {
+            postStatus = PostStatus.from(status);
+        } catch (IllegalArgumentException e) {
+            throw new JobException(JobErrorStatus.POST_STATUS_INVALID);
+        }
+        Boolean isActive = (postStatus == PostStatus.OPEN);
+        List<Job> jobs = jobRepository.findByUserIdAndIsActive(userId, isActive);
+
+        return jobs.stream()
+                .map(jobConverter::toMyPostResponseDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
@@ -4,6 +4,8 @@ import com.umc.tomorrow.domain.job.dto.request.*;
 import com.umc.tomorrow.domain.job.entity.*;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class JobConverter {
 
@@ -75,6 +77,20 @@ public class JobConverter {
                 .contact(dto.getContact())
                 .registrationPurpose(dto.getRegistrationPurpose())
                 .address(dto.getAddress())
+                .build();
+    }
+
+    public MyPostResponseDTO toMyPostResponseDto(Job job) {
+        return MyPostResponseDTO.builder()
+                .postId(job.getId())
+                .title(job.getTitle())
+                .status(job.getIsActive() ? "모집중" : "모집완료")
+                .date(job.getDeadline().toLocalDate())
+                .location(job.getLocation())
+                .tags(List.of(
+                        job.getJobCategory().getDescription()
+                        // 추후 WorkEnvironment 등에서 태그 추가 가능
+                ))
                 .build();
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/request/MyPostResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/request/MyPostResponseDTO.java
@@ -1,0 +1,39 @@
+/**
+ * MyPostResponseDto
+ * 내가 올린 직업 공고 확인하기 위한 DTO
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-25
+ */
+package com.umc.tomorrow.domain.job.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "내 공고 조회 응답 DTO")
+public class MyPostResponseDTO {
+
+    @Schema(description = "공고 ID", example = "301")
+    private Long postId;
+
+    @Schema(description = "공고 제목", example = "도서 정리 및 대출 보조")
+    private String title;
+
+    @Schema(description = "공고 상태", example = "모집중")
+    private String status; // 모집중 / 모집완료
+
+    @Schema(description = "공고 날짜", example = "2025-06-01")
+    private LocalDate date;
+
+    @Schema(description = "지역", example = "서울 서초구")
+    private String location;
+
+    @Schema(description = "작업 태그 목록", example = "[\"기본 물건 운반\", \"손이나 팔을 자주 사용하는 작업\"]")
+    private List<String> tags;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/response/MyPostListResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/response/MyPostListResponseDTO.java
@@ -1,0 +1,22 @@
+/**
+ * 내가 등록한 공고 리스트 응답 DTO
+ * 작성자: 정여진
+ * 생성일: 2025-07-25
+ *
+ * 설명:
+ * - 사용자가 등록한 공고(Post) 목록을 조회할 때 사용됩니다.
+ * - 내부에 MyPostResponseDto 리스트를 포함합니다.
+ */
+package com.umc.tomorrow.domain.job.dto.response;
+
+import com.umc.tomorrow.domain.job.dto.request.MyPostResponseDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MyPostListResponseDTO {
+    private List<MyPostResponseDTO> posts;
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/enums/JobCategory.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/enums/JobCategory.java
@@ -1,15 +1,21 @@
 package com.umc.tomorrow.domain.job.enums;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 public enum JobCategory {
-    SERVING,
-    KITCHEN_HELP,
-    CAFE_BAKERY,
-    TUTORING,
-    ERRAND,
-    PROMOTION,
-    SENIOR_CARE,
-    CHILD_CARE,
-    BEAUTY,
-    OFFICE_HELP,
-    ETC
+    SERVING("서빙"),
+    KITCHEN_HELP("주방 보조"),
+    CAFE_BAKERY("카페/베이커리"),
+    TUTORING("과외/교육"),
+    ERRAND("심부름"),
+    PROMOTION("홍보"),
+    SENIOR_CARE("노인 돌봄"),
+    CHILD_CARE("아이 돌봄"),
+    BEAUTY("미용"),
+    OFFICE_HELP("사무 보조"),
+    ETC("기타");
+
+    private final String description;
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/enums/PaymentType.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/enums/PaymentType.java
@@ -1,8 +1,16 @@
 package com.umc.tomorrow.domain.job.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum PaymentType {
-    HOURLY,     // 시급
-    PER_TASK,   // 건당
-    DAILY,      // 일급
-    MONTHLY     // 월급
+
+    HOURLY("시급"),
+    PER_TASK("건당"),
+    DAILY("일급"),
+    MONTHLY("월급");
+
+    private final String description;
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/enums/PostStatus.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/enums/PostStatus.java
@@ -1,0 +1,19 @@
+/**
+ * 공고 상태 Enum (모집중, 모집완료)
+ * 작성자: 정여진
+ * 생성일: 2025-07-25
+ */
+package com.umc.tomorrow.domain.job.enums;
+
+public enum PostStatus {
+    OPEN,   // 모집중
+    CLOSED; // 모집완료
+
+    public static PostStatus from(String status) {
+        return switch (status.toLowerCase()) {
+            case "open" -> OPEN;
+            case "closed" -> CLOSED;
+            default -> throw new IllegalArgumentException("Invalid post status: " + status);
+        };
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/enums/RegistrantType.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/enums/RegistrantType.java
@@ -1,6 +1,14 @@
 package com.umc.tomorrow.domain.job.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum RegistrantType {
-    PERSONAL,   // 개인
-    BUSINESS    // 사업자
+
+    PERSONAL("개인"),
+    BUSINESS("사업자");
+
+    private final String description;
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/exception/JobException.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/exception/JobException.java
@@ -1,0 +1,15 @@
+/**
+ * 공고 도메인 예외 클래스
+ * 작성자: 정여진
+ * 생성일: 2025-07-25
+ */
+package com.umc.tomorrow.domain.job.exception;
+
+import com.umc.tomorrow.domain.job.exception.code.JobErrorStatus;
+import com.umc.tomorrow.global.common.exception.RestApiException;
+
+public class JobException extends RestApiException {
+    public JobException(JobErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/exception/code/JobErrorStatus.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/exception/code/JobErrorStatus.java
@@ -3,7 +3,7 @@
  * 작성자: 정여진
  * 생성일: 2025-07-23
  */
-package com.umc.tomorrow.domain.job.exception;
+package com.umc.tomorrow.domain.job.exception.code;
 
 import com.umc.tomorrow.global.common.exception.code.BaseCode;
 import com.umc.tomorrow.global.common.exception.code.BaseCodeInterface;
@@ -16,7 +16,8 @@ import org.springframework.http.HttpStatus;
 public enum JobErrorStatus implements BaseCodeInterface {
 
     JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "JOB404", "공고를 찾을 수 없습니다."),
-    JOB_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "JOB4001", "마감된 공고입니다.");
+    JOB_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "JOB4001", "마감된 공고입니다."),
+    POST_STATUS_INVALID(HttpStatus.BAD_REQUEST, "JOB400", "잘못된 공고 상태입니다.");
 
     private final HttpStatus httpStatus;
     private final boolean isSuccess = false;

--- a/src/main/java/com/umc/tomorrow/domain/job/repository/JobRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/repository/JobRepository.java
@@ -1,10 +1,17 @@
+/**
+ * 공고 도메인 repository
+ * 작성자: 정여진
+ * 생성일: 2025-07-25
+ */
 package com.umc.tomorrow.domain.job.repository;
 
 import com.umc.tomorrow.domain.job.entity.Job;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface JobRepository extends JpaRepository<Job, Long> {
-
+    List<Job> findByUserIdAndIsActive(Long userId, Boolean isActive);
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/service/query/JobQueryService.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/service/query/JobQueryService.java
@@ -1,0 +1,21 @@
+/**
+ * 내 공고 조회 서비스 인터페이스
+ * 작성자: 정여진
+ * 생성일: 2025-07-25
+ */
+package com.umc.tomorrow.domain.job.service.query;
+
+import com.umc.tomorrow.domain.job.dto.request.MyPostResponseDTO;
+
+import java.util.List;
+
+public interface JobQueryService {
+
+    /**
+     * 상태별 공고 조회 (모집중 / 모집완료)
+     * @param userId 로그인한 사용자 ID
+     * @param status "open" 또는 "closed"
+     * @return 공고 응답 리스트
+     */
+    List<MyPostResponseDTO> getMyPosts(Long userId, String status);
+}


### PR DESCRIPTION
## 관련 이슈
- close #56 

## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- MyPostResponseDTO, MyPostListResponseDTO 작성
- GET /api/v1/my-posts?status=open|closed API 구현 (Service, Controller 포함)
- JobStatus 등 관련 Enum 리팩토링
- 공고 조회 결과에 공고 ID, 제목, 상태, 날짜, 지역, 태그 포함

related to #56
## 리뷰 포인트
- enums 일부 수정했습니다. label 통해서 값 받아올 수 있도록이요.

## 🖼스크린샷 (선택)
- swagger 캡쳐본입니다. (get /api/v1/my-posts?status=open|closed)

<img width="1085" height="848" alt="image" src="https://github.com/user-attachments/assets/fcc05b8d-b0e7-4f1b-bc9a-56e95530d92c" />
<img width="1004" height="462" alt="image" src="https://github.com/user-attachments/assets/634743d9-3be8-4ab5-a6da-1bc98a4afdd4" />
<img width="452" height="785" alt="image" src="https://github.com/user-attachments/assets/9abd88e0-89a9-4485-a349-450218c19a9a" />
