### PR TITLE
feat: 지원자 조회 및 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/controller/ApplicationController.java
@@ -8,6 +8,7 @@
 package com.umc.tomorrow.domain.application.controller;
 
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicantListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
@@ -73,6 +74,22 @@ public class ApplicationController {
                 postId,
                 applicantId
         );
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+    }
+
+    @Operation(
+            summary = "지원자 목록 조회 (공고 기준)",
+            description = "`status`가 없으면 전체, `status=open` 또는 `status=closed`로 필터링합니다."
+    )
+    @GetMapping("/{postId}/applicants")
+    public ResponseEntity<BaseResponse<List<ApplicantListResponseDTO>>> getApplicantsByPost(
+            @Parameter(description = "공고 ID", example = "301")
+            @PathVariable @Min(1) Long postId,
+
+            @Parameter(description = "지원 상태 필터 (생략 시 전체 조회)", example = "closed")
+            @RequestParam(required = false) String status
+    ) {
+        List<ApplicantListResponseDTO> result = applicationService.getApplicantsByPostAndStatus(postId, status);
         return ResponseEntity.ok(BaseResponse.onSuccess(result));
     }
 } 

--- a/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
@@ -7,6 +7,7 @@
 package com.umc.tomorrow.domain.application.converter;
 
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
+import com.umc.tomorrow.domain.application.dto.response.ApplicantListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
@@ -119,6 +120,16 @@ public class ApplicationConverter {
     // Certificate 엔티티를 CertificationDTO로 변환
     private static ApplicationDetailsResponseDTO.CertificationDTO toCertificationDTO(Certificate certificate) {
         return ApplicationDetailsResponseDTO.CertificationDTO.builder()
+                .build();
+    }
+
+    public static ApplicantListResponseDTO toApplicantListResponseDTO(Application application) {
+        return ApplicantListResponseDTO.builder()
+                .applicantId(application.getUser().getId())
+                .userName(application.getUser().getName())
+                .applicationDate(application.getCreatedAt())
+                .status(application.getStatus().getLabel())
+                .resumeTitle(application.getResume() != null ? application.getResume().toString() : null) // 또는 "없음"
                 .build();
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicantListResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicantListResponseDTO.java
@@ -1,0 +1,22 @@
+/**
+ * 관리자(또는 등록자)가 특정 공고(postId)에 지원한 '지원자 목록'을 조회하기 위해
+ *
+ * 작성자: 정여진
+ * 생성일: 2025-07-26
+ */
+package com.umc.tomorrow.domain.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ApplicantListResponseDTO {
+    private Long applicantId;
+    private String userName;
+    private LocalDateTime applicationDate;
+    private String status;
+    private String resumeTitle;
+}

--- a/src/main/java/com/umc/tomorrow/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/repository/ApplicationRepository.java
@@ -51,4 +51,9 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
      * 사용자의 ID, 상태(합격/불합)에 따라 공고 조회
      */
     List<Application> findAllByUserIdAndStatus(Long userId, ApplicationStatus status);
+
+    /**
+     * 직업 id에 따라 모든 직업 조회
+     * */
+    List<Application> findAllByJobId(Long jobId);
 }

--- a/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationService.java
@@ -10,6 +10,7 @@ package com.umc.tomorrow.domain.application.service.command;
 import com.umc.tomorrow.domain.application.converter.ApplicationConverter;
 import com.umc.tomorrow.domain.application.dto.request.UpdateApplicationStatusRequestDTO;
 
+import com.umc.tomorrow.domain.application.dto.response.ApplicantListResponseDTO;
 import com.umc.tomorrow.domain.application.dto.response.ApplicationStatusListResponseDTO;
 
 import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsResponseDTO;
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -92,6 +94,41 @@ public class ApplicationService {
                 user,
                 resume
         );
+    }
+
+    /**
+     * 공고 기준 지원자 목록 조회
+     * status : null이면 전체, open이면 모집중, closed면 모집완료
+     * */
+    private boolean isJobClosed(Job job) {
+        LocalDateTime now = LocalDateTime.now();
+        boolean deadlinePassed = job.getDeadline().isBefore(now);
+        boolean manuallyClosed = Boolean.FALSE.equals(job.getIsActive());
+        return deadlinePassed || manuallyClosed;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApplicantListResponseDTO> getApplicantsByPostAndStatus(Long postId, String status) {
+        Job job = jobRepository.findById(postId)
+                .orElseThrow(() -> new RestApiException(JobErrorStatus.JOB_NOT_FOUND));
+
+        boolean isClosed = isJobClosed(job);
+
+        List<Application> applications;
+        if (status == null || status.isBlank()) {
+            // 전체
+            applications = applicationRepository.findAllByJobId(postId);
+        } else if (status.equalsIgnoreCase("open")) {
+            applications = isClosed ? List.of() : applicationRepository.findAllByJobId(postId);
+        } else if (status.equalsIgnoreCase("closed")) {
+            applications = isClosed ? applicationRepository.findAllByJobId(postId) : List.of();
+        } else {
+            throw new RestApiException(ApplicationErrorStatus.INVALID_STATUS);
+        }
+
+        return applications.stream()
+                .map(ApplicationConverter::toApplicantListResponseDTO)
+                .collect(Collectors.toList());
     }
 
 } 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     basename: validation
 
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE}
+    active: ${SPRING_PROFILES_ACTIVE:local}
     
 
   # JPA 설정 
@@ -40,6 +40,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             scope: name, email, gender, mobile
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
           google:
             client-name: google
@@ -47,12 +48,14 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             scope: profile, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
           
           kakao:
             client-name: kakao
             client-id: ${KAKAO_CLIENT_ID}
             authorization-grant-type: authorization_code
             scope: profile_nickname, profile_image
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
         provider:
           naver:


### PR DESCRIPTION
## 관련 이슈
- close #58 

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 게시글별 지원자 전체 조회 API 구현 (/api/v1/posts/{postId}/applicants) 
- status 파라미터가 null인 경우 전체 지원자 반환 
- Application → ApplicantListResponseDTO 변환 로직 
- 게시글별 지원자 모집 완료 전, 후 API 구현 (/api/v1/posts/{postId}/applicants?status=closed,open)

related to #58

## 리뷰 포인트
- 없습니다.

## 🖼스크린샷 (선택)
- swagger 캡쳐본입니다.
1) 200 게시글 전체조회(get /api/v1/posts/{postId}/applicants, 즉 status = null 인 경우)
<img width="592" height="764" alt="image" src="https://github.com/user-attachments/assets/fd6ac6ad-c373-4835-99b7-4aeb512b72fc" />
2) 200 지원자 모집 완료 전 API (get /api/v1/posts/{postId}/applicants/status=open )
<img width="440" height="669" alt="image" src="https://github.com/user-attachments/assets/cb04fdcd-8087-4dc8-9f68-30ae163ac26b" />
3) 200 지원자 모집 완료 후 API(get /api/v1/posts/{postId}/applicants/status=closed)
<img width="611" height="678" alt="image" src="https://github.com/user-attachments/assets/5dfe2587-6a71-43e8-8576-6a5d23f5fda2" />

4) 404 공고 없을 때 예외처리
<img width="620" height="725" alt="image" src="https://github.com/user-attachments/assets/bc8bfd09-ec03-4e22-8555-1354dde75400" />
