### PR TITLE
Refactor: 일자리 등록 로직 개선

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/job/controller/JobCommandController.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/controller/JobCommandController.java
@@ -1,13 +1,18 @@
 package com.umc.tomorrow.domain.job.controller;
 
+import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
 import com.umc.tomorrow.domain.job.dto.request.BusinessRequestDTO;
 import com.umc.tomorrow.domain.job.dto.request.JobRequestDTO;
 import com.umc.tomorrow.domain.job.dto.request.PersonalRequestDTO;
+import com.umc.tomorrow.domain.job.dto.response.JobCreateResponseDTO;
 import com.umc.tomorrow.domain.job.dto.response.JobStepResponseDTO;
+import com.umc.tomorrow.domain.job.enums.RegistrantType;
 import com.umc.tomorrow.domain.job.service.command.JobCommandService;
 import com.umc.tomorrow.domain.member.entity.User;
 import com.umc.tomorrow.domain.member.repository.UserRepository;
 import com.umc.tomorrow.global.common.base.BaseResponse;
+import com.umc.tomorrow.global.common.exception.RestApiException;
+import com.umc.tomorrow.global.common.exception.code.GlobalErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
@@ -24,40 +29,107 @@ import org.springframework.web.bind.annotation.*;
 public class JobCommandController {
 
     private final JobCommandService jobCommandService;
+    private final UserRepository userRepository;
 
+
+    /**
+     * 일자리 정보 세션에 저장(POST)
+     * @param user 인증된 사용자
+     * @param requestDTO 일자리 데이터 요청 DTO
+     * @param session 세션 사용
+     * @return 성공 응답
+     */
     @Operation(summary = "일자리 등록 폼 작성", description = "검증된 사용자가 일자리 폼을 작성합니다.")
     @PostMapping
     public ResponseEntity<BaseResponse<JobStepResponseDTO>> saveJobStepOne(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal CustomOAuth2User user,
             @Valid @RequestBody JobRequestDTO requestDTO,
             HttpSession session
     ) {
-        JobStepResponseDTO result = jobCommandService.saveInitialJobStep(user.getId(), requestDTO, session);
+        Long userId = user.getUserDTO().getId();
+
+        JobStepResponseDTO result = jobCommandService.saveInitialJobStep(userId, requestDTO, session);
         return ResponseEntity.ok(BaseResponse.onSuccess(result));
     }
 
 
-    // 사업자 등록 API
-    @Operation(summary = "사업자 인증", description = "일자리 등록 페이지에서 회사를 선택한 사람은 사업자 인증 페이지로 이동한다")
-    @PostMapping("/business-verifications")
-    public ResponseEntity<BaseResponse<Object>> saveBusinessVerification(
-            @AuthenticationPrincipal User user,
-            @Valid @RequestBody BusinessRequestDTO requestDTO
-    ) {
-        jobCommandService.saveBusinessVerification(user.getId(), requestDTO);
-
-        return ResponseEntity.ok(BaseResponse.onSuccess("verifications_suceess"));
-    }
-
+    /**
+     * 일자리, 개인 등록 사유 정보 db에 저장(POST)
+     * @param user 인증된 사용자
+     * @param requestDTO 일자리 데이터 요청 DTO
+     * @param session 세션 사용
+     * @return 성공 응답
+     */
     // 개인 등록 API
     @Operation(summary = "개인 등록 사유", description = "일자리 등록 페이지에서 개인를 선택한 사람은 개인 등록 사유 페이지로 이동한다")
-    @PostMapping("/personal-registrations")
-    public ResponseEntity<BaseResponse<Object>> savePersonalRegistration(
-            @AuthenticationPrincipal User user,
-            @Valid @RequestBody PersonalRequestDTO requestDTO
+    @PostMapping("/personal_registrations")
+    public ResponseEntity<BaseResponse<JobCreateResponseDTO>> savePersonalRegistration(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Valid @RequestBody PersonalRequestDTO requestDTO,
+            HttpSession session
     ) {
-        jobCommandService.savePersonalRegistration(user.getId(), requestDTO);
+        Long userId = user.getUserDTO().getId();
 
-        return ResponseEntity.ok(BaseResponse.onSuccess("personal-registrations_suceess"));
+        JobCreateResponseDTO result = jobCommandService.savePersonalRegistration(userId, requestDTO, session);
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+    }
+
+
+    /**
+     * 세션이 넘어온 경우 바로 일자리 등록, 아닐 경우 사업자 등록 페이지로 이동(POST)
+     * @param user 인증된 사용자
+     * @param requestDTO 일자리 데이터 요청 DTO
+     * @param session 세션 사용
+     * @return 성공 응답
+     */
+    @Operation(summary = "사업자 등록 페이지 진입", description = "세션에 job이 있으면 일자리 등록까지 진행")
+    @PostMapping("/business-verifications/register")
+    public ResponseEntity<BaseResponse<JobStepResponseDTO>> registerBusiness(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Valid @RequestBody BusinessRequestDTO requestDTO,
+            HttpSession session
+    ) {
+        Long userId = user.getUserDTO().getId();
+
+        // 세션에 job이 있다면사업자 등록 후 job 생성까지
+        JobRequestDTO jobDTO = (JobRequestDTO) session.getAttribute("job_session");
+
+        if (jobDTO != null) {
+            JobCreateResponseDTO result = jobCommandService.registerBusinessAndCreateJob(userId, requestDTO, session);
+            return ResponseEntity.ok(BaseResponse.onSuccess(
+                    JobStepResponseDTO.builder()
+                            .step("job_created")
+                            .jobId(result.getJobId())
+                            .registrantType(RegistrantType.BUSINESS)
+                            .build()
+            ));
+        }
+
+        // 세션에 job이 없다면 /business-verifications/only페이지로 이동(프론트에서 처리)
+        jobCommandService.saveBusinessVerification(userId, requestDTO);
+        return ResponseEntity.ok(BaseResponse.onSuccess(
+                JobStepResponseDTO.builder()
+                        .step("business-verifications/only")
+                        .registrantType(RegistrantType.BUSINESS)
+                        .build()
+        ));
+    }
+
+    /**
+     * 사업자 등록 요청 페이지(POST)
+     * @param user 인증된 사용자
+     * @param requestDTO 일자리 데이터 요청 DTO
+     * @return 성공 응답
+     */
+    @Operation(summary = "사업자 정보만 등록", description = "유저가 사업자 정보만 등록하고 일자리는 등록하지 않는 경우")
+    @PostMapping("/business-verifications/only")
+    public ResponseEntity<BaseResponse<Void>> registerBusinessOnly(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Valid @RequestBody BusinessRequestDTO requestDTO
+    ) {
+        Long userId = user.getUserDTO().getId();
+        jobCommandService.saveBusinessVerification(userId, requestDTO);
+        return ResponseEntity.ok(BaseResponse.onSuccess(null));
+
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
@@ -31,6 +31,7 @@ public class JobConverter {
                 .alwaysHiring(dto.getAlwaysHiring())
                 .workDays(toWorkDays(dto.getWorkDays()))
                 .workEnvironment(toWorkEnvironment(dto.getWorkEnvironment()))
+                .jobCategory(dto.getJobCategory())
                 .build();
     }
 

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/request/JobRequestDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/request/JobRequestDTO.java
@@ -1,5 +1,6 @@
 package com.umc.tomorrow.domain.job.dto.request;
 
+import com.umc.tomorrow.domain.job.enums.JobCategory;
 import com.umc.tomorrow.domain.job.enums.PaymentType;
 import com.umc.tomorrow.domain.job.enums.RegistrantType;
 import com.umc.tomorrow.domain.job.enums.WorkPeriod;
@@ -47,6 +48,10 @@ public class JobRequestDTO {
     @NotNull(message = "{job.paymentType.notnull}")
     private PaymentType paymentType;
 
+    @Schema(description = "일자리 카테고리", example = "TUTORING", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "{job.jobCategory.notnull}")
+    private JobCategory jobCategory;
+
     @Schema(description = "급여",
             example = "12000",
             requiredMode = Schema.RequiredMode.REQUIRED)
@@ -80,7 +85,7 @@ public class JobRequestDTO {
     private Integer recruitmentLimit;
 
     @Schema(description = "등록유형",
-            example = "BUSINESS",
+            example = "PERSONAL",
             requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "{job.registrantType.notnull}")
     private RegistrantType registrantType;

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/request/PersonalRequestDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/request/PersonalRequestDTO.java
@@ -22,13 +22,13 @@ public class PersonalRequestDTO {
     private String name;
 
     @Schema(description = "위도",
-            example = "122323.3233",
+            example = "123.333",
             requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "{personal.latitude.notnull}") // 지도 api 구현하고 필수로
     private BigDecimal latitude;
 
     @Schema(description = "경도",
-            example = "12.32211",
+            example = "12.321",
             requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "{personal.longitude.notnull}") // 지도 api 구현하고 필수로
     private BigDecimal longitude;

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/response/JobStepResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/response/JobStepResponseDTO.java
@@ -14,8 +14,8 @@ public class JobStepResponseDTO {
     @Schema(description = "개인 or 회사", example = "BUSINESS")
     private RegistrantType registrantType;
 
-    @Schema(description = "일자리 폼 저장 상태", example = "job_form_saved")
+    @Schema(description = "저장 상태", example = "job_form_saved")
     private String step;
 
-    private User user;
+    private Long jobId;
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/BusinessVerification.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/BusinessVerification.java
@@ -1,5 +1,6 @@
 package com.umc.tomorrow.domain.job.entity;
 
+import com.umc.tomorrow.domain.member.entity.User;
 import com.umc.tomorrow.global.common.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -30,5 +31,7 @@ public class BusinessVerification extends BaseEntity {
     private LocalDate openingDate;
 
     //연관관계
+    @OneToOne(mappedBy = "businessVerification")
+    private User user;
 
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
@@ -20,8 +20,7 @@ import java.util.List;
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_job_work_env", columnNames = "work_environment_id"),
                 @UniqueConstraint(name = "uk_job_personal_reg", columnNames = "personal_registration_id"),
-                @UniqueConstraint(name = "uk_job_work_days", columnNames = "work_days_id"),
-                @UniqueConstraint(name = "uk_job_business_verification", columnNames = "business_verification_id")
+                @UniqueConstraint(name = "uk_job_work_days", columnNames = "work_days_id")
         })
 @Getter
 @Setter
@@ -79,7 +78,7 @@ public class Job extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     //private RegistrantType registrantType;
-    private RegistrantType registrantType = RegistrantType.BUSINESS;//테스트용
+    private RegistrantType registrantType = RegistrantType.PERSONAL;//테스트용
 
     @Column(nullable = false)
     private LocalDateTime deadline;
@@ -99,15 +98,9 @@ public class Job extends BaseEntity {
     @Column(columnDefinition = "BOOLEAN DEFAULT false")
     private Boolean alwaysHiring;
 
-    //businessVerification와 1:1관계
-    @OneToOne(cascade = CascadeType.ALL, optional = false)
-    @JoinColumn(name = "business_verification_id", nullable = false,
-            foreignKey = @ForeignKey(name = "fk_job_business_verification"))
-    private BusinessVerification businessVerification;
-
     //personalRegistration와 1:1관계
-    @OneToOne(cascade = CascadeType.ALL, optional = false)
-    @JoinColumn(name = "personal_registration_id", nullable = false,
+    @OneToOne(cascade = CascadeType.ALL, optional = true)
+    @JoinColumn(name = "personal_registration_id", nullable = true,
             foreignKey = @ForeignKey(name = "fk_job_personal_registration"))
     private PersonalRegistration personalRegistration;
 

--- a/src/main/java/com/umc/tomorrow/domain/job/service/command/JobCommandService.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/service/command/JobCommandService.java
@@ -3,14 +3,32 @@ package com.umc.tomorrow.domain.job.service.command;
 import com.umc.tomorrow.domain.job.dto.request.BusinessRequestDTO;
 import com.umc.tomorrow.domain.job.dto.request.JobRequestDTO;
 import com.umc.tomorrow.domain.job.dto.request.PersonalRequestDTO;
+import com.umc.tomorrow.domain.job.dto.response.JobCreateResponseDTO;
 import com.umc.tomorrow.domain.job.dto.response.JobStepResponseDTO;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 
 public interface JobCommandService {
 
-    JobStepResponseDTO saveInitialJobStep(Long userId,JobRequestDTO requestDTO, HttpSession session);
+    /**
+     * Step1. 기본 일자리 정보 (폼) 저장 (세션에 보관)
+     */
+    JobStepResponseDTO saveInitialJobStep(Long userId, JobRequestDTO requestDTO, HttpSession session);
+
+    /**
+     * Step2. 개인 등록 시: Personal 정보 저장 + Job 생성
+     */
+    JobCreateResponseDTO savePersonalRegistration(Long userId, PersonalRequestDTO requestDTO, HttpSession session);
+
+    /**
+     * Step2-1. 사업자 등록이 이미 되어있는 경우: 바로 Job 생성
+     */
+    JobCreateResponseDTO createJobWithExistingBusiness(Long userId, HttpSession session);
+    
+    /**
+     * Step2-2. 사업자 등록이 안 되어 있는 경우: Business 등록 후 Job 생성
+     */
+    JobCreateResponseDTO registerBusinessAndCreateJob(Long userId, BusinessRequestDTO requestDTO, HttpSession session);
 
     void saveBusinessVerification(Long userId, BusinessRequestDTO requestDTO);
-
-    void savePersonalRegistration(Long userId, PersonalRequestDTO requestDTO);
 }

--- a/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
@@ -1,6 +1,7 @@
 package com.umc.tomorrow.domain.member.entity;
 
 import com.umc.tomorrow.domain.application.entity.Application;
+import com.umc.tomorrow.domain.job.entity.BusinessVerification;
 import com.umc.tomorrow.domain.job.entity.Job;
 import com.umc.tomorrow.domain.member.enums.Gender;
 import com.umc.tomorrow.domain.member.enums.Provider;
@@ -72,5 +73,11 @@ public class User {
     //연관관계
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Job> jobs = new ArrayList<>(); // 내가 등록한 일자리 목록
+
+
+    // 사업자 등록 테이블과 1ㄷ1 연결
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "business_verification_id", unique = true)
+    private BusinessVerification businessVerification;
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             scope: name, email, gender, mobile
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
           google:
             client-name: google
@@ -47,12 +48,14 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             scope: profile, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
           
           kakao:
             client-name: kakao
             client-id: ${KAKAO_CLIENT_ID}
             authorization-grant-type: authorization_code
             scope: profile_nickname, profile_image
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
         provider:
           naver:

--- a/src/main/resources/validation.properties
+++ b/src/main/resources/validation.properties
@@ -54,7 +54,7 @@ job.location.notblank=주소는 필수입니다.
 job.alwaysHiring.notnull=상시 모집 여부는 필수입니다.
 job.workDays.notnull=근무 요일 정보는 필수입니다.
 job.workEnvironment.notnull=근무 환경 정보는 필수입니다.
-
+job.jobCategory.notnull=일자리 카테로기는 필수입니다.
 
 # 개인 사유 등록
 personal.name.notnull=이름은 필수입니다.


### PR DESCRIPTION
## 관련 이슈
- close #62

## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 일자리 등록 시 개인을 선택할 경우 개인 등록 정보를 입력 받고 일자리를 등록할 수 있습니다.
- 회사를 선택 시 사업자 정보가 유저에 등록되어 있다면 바로 일자리가 생성되고 없을 경우 사업자 등록 페이지로 이동합니다.

## 리뷰 포인트
- 예외 처리는 추후 더 추가하겠습니다.

## 🖼스크린샷 (선택)
- 일자리 폼 등록 시
<img width="1992" height="582" alt="1" src="https://github.com/user-attachments/assets/657bb730-cbfd-44aa-92b9-ee2792738393" />

- 개인 등록
<img width="1686" height="574" alt="2" src="https://github.com/user-attachments/assets/d7e31eb1-976b-48bc-90fd-ad8ded155ce7" />

- 사업자 등록
<img width="1408" height="474" alt="3" src="https://github.com/user-attachments/assets/e3e2ea17-e97c-4c79-9d90-3558642ddd15" />
<img width="1560" height="528" alt="4" src="https://github.com/user-attachments/assets/5fece43d-9aca-4a39-81df-c62856c08030" />

