### PR TITLE
feat: JWT 인증/토큰 재발급 로직 개선 및 예외 처리 정비

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import com.umc.tomorrow.domain.auth.jwt.JWTUtil;
 import com.umc.tomorrow.domain.member.entity.User;
 import com.umc.tomorrow.domain.member.repository.UserRepository;
 import com.umc.tomorrow.global.common.exception.RestApiException;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,30 +38,14 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshToken(HttpServletRequest request, @RequestHeader(value = "RefreshToken", required = false) String refreshTokenHeader) {
-        // 1. 쿠키에서 refreshToken 추출
-        String refreshToken = refreshTokenHeader;
-
-        if (refreshToken == null || refreshToken.isBlank()) {
-            Cookie[] cookies = request.getCookies();
-            if (cookies != null) {
-                refreshToken = Arrays.stream(cookies)
-                        .filter(cookie -> "RefreshToken".equals(cookie.getName()))
-                        .map(Cookie::getValue)
-                        .findFirst()
-                        .orElse(null);
-            }
-        }
-
-        System.out.println("DEBUG: RefreshToken value = '" + refreshToken + "'");
-        // 2. 빈 문자열 체크
+    public ResponseEntity<?> refreshToken(@RequestHeader(value = "RefreshToken", required = false) String refreshToken, HttpServletResponse response) {
+        // 1. 빈 문자열 체크
         if (refreshToken == null || refreshToken.isBlank()) {
             throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_NOT_FOUND);
         }
 
         try {
-            System.out.println("만료 여부 확인 전");
-            // 토큰 만료 여부 먼저 확인해야 함.
+            // 2. 토큰 만료 여부 먼저 확인해야 함.
             if (jwtUtil.isExpired(refreshToken)) {
                 throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_EXPIRED); // AUTH4002
             }
@@ -69,28 +54,34 @@ public class AuthController {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new RestApiException(AuthErrorStatus.REFRESH_TOKEN_INVALID));
 
-            if (user == null || user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) { // 아 여기가 문제네.
+            if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) { // 아 여기가 문제네.
                 throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_INVALID);
             }
 
             // 새 accessToken, 새 refreshToken 생성
             String newAccessToken = jwtUtil.createJwt(user.getId(), user.getName(), ACCRESS_EXP_MIN);
-            String newRefreshToken = jwtUtil.createRefreshToken(user.getId(), user.getName(), REFRESH_EXP_MIN); // 예: 14일
+            String newRefreshToken = jwtUtil.createRefreshToken(user.getId(), user.getName(), REFRESH_EXP_MIN); // 14일
 
             // DB에 새 refreshToken 저장
             user.setRefreshToken(newRefreshToken);
             userRepository.save(user);
 
+            // refreshToken을 HttpOnly 쿠키로 변경한다.
+            Cookie cookie = new Cookie("refreshToken", newRefreshToken);
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true); // HTTPS 환경에서만 전송
+            cookie.setPath("/");
+            cookie.setMaxAge((int) (REFRESH_EXP_MIN / 1000L));
+            cookie.setDomain("localhost"); // 배포 시 실제 도메인으로 변경
+            response.addCookie(cookie);
+
             // 응답에 둘 다 포함
             return ResponseEntity.ok().body(Map.of(
-                    "accessToken", newAccessToken,
-                    "refreshToken", newRefreshToken
+                    "accessToken", newAccessToken
             ));
-
         } catch (RestApiException e) {
             throw e; // 전체 Exception이 아니라 RestAPIException으로
         } catch (Exception e){
-            System.err.println("리프레시 토큰 검증 로직 중 예외 발생: " + e.getMessage());
             throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_INVALID); // AUTH4003
         }
     }

--- a/src/main/java/com/umc/tomorrow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/controller/AuthController.java
@@ -3,19 +3,23 @@
  * - POST /api/v1/auth/refresh : 리프레시 토큰으로 액세스 토큰 재발급
  * 
  * 작성자: 정여진
- * 생성일: 2025-07-07
+ * 작성일: 2025-07-07
+ * 수정일 : 2025-07-29
  */
 package com.umc.tomorrow.domain.auth.controller;
 
+import com.umc.tomorrow.domain.auth.exception.code.AuthErrorStatus;
 import com.umc.tomorrow.domain.auth.jwt.JWTUtil;
 import com.umc.tomorrow.domain.member.entity.User;
 import com.umc.tomorrow.domain.member.repository.UserRepository;
+import com.umc.tomorrow.global.common.exception.RestApiException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -23,6 +27,9 @@ public class AuthController {
 
     private final JWTUtil jwtUtil;
     private final UserRepository userRepository;
+
+    public static final long REFRESH_EXP_MIN = 1000L * 60L * 60L * 24L * 14L; // 2주
+    public static final long ACCRESS_EXP_MIN = 60 * 60 * 1000L; // 1시간
 
     public AuthController(JWTUtil jwtUtil, UserRepository userRepository) {
         this.jwtUtil = jwtUtil;
@@ -33,7 +40,8 @@ public class AuthController {
     public ResponseEntity<?> refreshToken(HttpServletRequest request, @RequestHeader(value = "RefreshToken", required = false) String refreshTokenHeader) {
         // 1. 쿠키에서 refreshToken 추출
         String refreshToken = refreshTokenHeader;
-        if (refreshToken == null) {
+
+        if (refreshToken == null || refreshToken.isBlank()) {
             Cookie[] cookies = request.getCookies();
             if (cookies != null) {
                 refreshToken = Arrays.stream(cookies)
@@ -43,31 +51,47 @@ public class AuthController {
                         .orElse(null);
             }
         }
-        if (refreshToken == null) {
-            return ResponseEntity.badRequest().body("Refresh token not found");
+
+        System.out.println("DEBUG: RefreshToken value = '" + refreshToken + "'");
+        // 2. 빈 문자열 체크
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_NOT_FOUND);
         }
-        // 2. 토큰 유효성 검사 및 사용자 조회
+
         try {
-            // 만료 여부 확인
+            System.out.println("만료 여부 확인 전");
+            // 토큰 만료 여부 먼저 확인해야 함.
             if (jwtUtil.isExpired(refreshToken)) {
-                return ResponseEntity.status(401).body("Refresh token expired");
+                throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_EXPIRED); // AUTH4002
             }
-            // username 추출
-            String username = jwtUtil.getUsername(refreshToken);
-            // DB에서 사용자 조회
-            User user = userRepository.findByUsername(username);
-            if (user == null || user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
-                return ResponseEntity.status(401).body("Invalid refresh token");
+
+            Long userId = jwtUtil.getUserId(refreshToken);
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new RestApiException(AuthErrorStatus.REFRESH_TOKEN_INVALID));
+
+            if (user == null || user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) { // 아 여기가 문제네.
+                throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_INVALID);
             }
-            // accessToken 재발급
-            String newAccessToken = jwtUtil.createJwt(
-                user.getId(),
-                user.getName(),
-                60*60*60L
-            ); // 기존과 동일한 만료시간
-            return ResponseEntity.ok().body(newAccessToken);
-        } catch (Exception e) {
-            return ResponseEntity.status(401).body("Invalid refresh token");
+
+            // 새 accessToken, 새 refreshToken 생성
+            String newAccessToken = jwtUtil.createJwt(user.getId(), user.getName(), ACCRESS_EXP_MIN);
+            String newRefreshToken = jwtUtil.createRefreshToken(user.getId(), user.getName(), REFRESH_EXP_MIN); // 예: 14일
+
+            // DB에 새 refreshToken 저장
+            user.setRefreshToken(newRefreshToken);
+            userRepository.save(user);
+
+            // 응답에 둘 다 포함
+            return ResponseEntity.ok().body(Map.of(
+                    "accessToken", newAccessToken,
+                    "refreshToken", newRefreshToken
+            ));
+
+        } catch (RestApiException e) {
+            throw e; // 전체 Exception이 아니라 RestAPIException으로
+        } catch (Exception e){
+            System.err.println("리프레시 토큰 검증 로직 중 예외 발생: " + e.getMessage());
+            throw new RestApiException(AuthErrorStatus.REFRESH_TOKEN_INVALID); // AUTH4003
         }
     }
 } 

--- a/src/main/java/com/umc/tomorrow/domain/auth/exception/code/AuthErrorStatus.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/exception/code/AuthErrorStatus.java
@@ -1,0 +1,29 @@
+package com.umc.tomorrow.domain.auth.exception.code;
+
+import com.umc.tomorrow.global.common.exception.code.BaseCode;
+import com.umc.tomorrow.global.common.exception.code.BaseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorStatus implements BaseCodeInterface {
+
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4001", "리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4002", "리프레시 토큰이 만료되었습니다. 다시 로그인해주세요."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH4003", "유효하지 않은 리프레시 토큰입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCode getCode() {
+        return BaseCode.builder()
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
@@ -35,8 +35,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         //OAuth2User
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
-
-        String username = customUserDetails.getUsername();
+        String usernameToUseForTokens;
+        // String username = customUserDetails.getUsername();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
@@ -51,59 +51,76 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         if (user == null) {
             // 소셜 로그인 정보로 새 회원 생성
             user = new User();
-            user.setName(customUserDetails.getName()); // 필요시
+            user.setName(customUserDetails.getName());
             // 필수값 세팅
             user.setCreatedAt(java.time.LocalDateTime.now());
             user.setUpdatedAt(java.time.LocalDateTime.now());
             // provider, providerUserId, username, email 세팅
-            providerStr = customUserDetails.getUserDTO().getProvider();
-            providerUserId = customUserDetails.getUserDTO().getProviderUserId();
-            if (providerStr != null) {
-                user.setProvider(Provider.valueOf(providerStr.toUpperCase()));
-            }
+            user.setProvider(Provider.valueOf(providerStr.toUpperCase()));
             user.setProviderUserId(providerUserId);
-            // username은 provider + '_' + providerUserId로 생성
-            String usernameValue = (providerStr != null && providerUserId != null) ? providerStr + "_" + providerUserId : null;
-            user.setUsername(usernameValue);
+
+            // DB에 저장할 username 형식과 토큰에 담을 username 형식을 일치시킴
+            usernameToUseForTokens = (providerStr != null && providerUserId != null) ? providerStr + "_" + providerUserId : null;
+            user.setUsername(usernameToUseForTokens); // DB에 저장
             user.setEmail(customUserDetails.getUserDTO().getEmail());
             userRepository.save(user);
+        }else {
+            // 기존 사용자일 경우 db에 저장된 username 사용
+            usernameToUseForTokens = user.getUsername();
+            // null 체크 추가 (혹시 기존 유저의 username이 null일 경우 대비)
+            if (usernameToUseForTokens == null) {
+                // DB에 username이 없었던 경우, 새로 생성하여 업데이트
+                usernameToUseForTokens = (providerStr != null && providerUserId != null) ? providerStr + "_" + providerUserId : null;
+                user.setUsername(usernameToUseForTokens);
+                userRepository.save(user);
+            }
         }
-        String token = jwtUtil.createJwt(
+
+        // Access Token 유효기간 (60시간)
+        long accessTokenExpiredMs = 60L * 60 * 60 * 1000; // 밀리초
+        long accessTokenExpiredSeconds = 60L * 60 * 60; // 초
+
+        // access token 생
+        String accessToken = jwtUtil.createJwt(
             user.getId(),
             user.getName(),
             user.getUsername(),
             (user.getStatus() != null ? user.getStatus().name() : null),
-            60*60*60L
+                accessTokenExpiredMs
         );
 
+        // Refresh Token 유효기간 (2주)
+        long refreshTokenExpiredMs = 60L * 60 * 24 * 14 * 1000; // 밀리초
+        long refreshTokenExpiredSeconds = 60L * 60 * 24 * 14; // 초
+
         // Refresh Token 생성 (2주)
-        String refreshToken = jwtUtil.createRefreshToken(username, 60L * 60 * 24 * 14 * 1000); // 2주
+        String refreshToken = jwtUtil.createRefreshToken(user.getId(), usernameToUseForTokens, refreshTokenExpiredMs); // 2주
 
         // DB에 저장
         if (user != null) {
             user.setRefreshToken(refreshToken);
+            System.out.println("[DEBUG] refresh Token 확인 : " + refreshToken);
             userRepository.save(user);
         }
 
         // 클라이언트에 전달 (쿠키/헤더)
-        response.addCookie(createCookie("Authorization", token));
-        response.addHeader("Authorization", "Bearer " + token);
-        response.addCookie(createCookie("RefreshToken", refreshToken));
+        response.addCookie(createCookie("Authorization", accessToken, (int)accessTokenExpiredSeconds));
+        response.addHeader("Authorization", "Bearer " + accessToken);
+
+        response.addCookie(createCookie("RefreshToken", refreshToken, (int)refreshTokenExpiredSeconds));
         response.addHeader("RefreshToken", refreshToken);
         //response.sendRedirect("http://localhost:3000/");
         //response.sendRedirect("/success");//로컬 테스트 확인용
     }
 
-    private Cookie createCookie(String key, String value) {
+    private Cookie createCookie(String key, String value, int maxAge) {
 
         Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60*60*60);
+        cookie.setMaxAge(maxAge);
         //cookie.setSecure(true);
         cookie.setSecure(false); // 로컬 테스트용
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-
-
 
         return cookie;
     }

--- a/src/main/java/com/umc/tomorrow/domain/member/dto/UserDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/dto/UserDTO.java
@@ -8,6 +8,7 @@
  */
 package com.umc.tomorrow.domain.member.dto;
 
+import jakarta.persistence.EntityListeners;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,7 +18,10 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import com.umc.tomorrow.domain.member.enums.Gender;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Builder
 public class UserDTO {
@@ -47,7 +51,8 @@ public class UserDTO {
     @NotNull(message = "{user.status.notnull}")
     private final String status; // 상태 (ACTIVE, INACTIVE)
 
-    private final LocalDateTime inactiveAt; // 비활성화 일시
+    @LastModifiedDate
+    private LocalDateTime inactiveAt; // 비활성화 일시
 
     @NotNull(message = "{user.isOnboarded.notnull}")
     private final Boolean isOnboarded; // 온보딩 여부
@@ -59,8 +64,10 @@ public class UserDTO {
     @Size(max = 10, message = "{user.providerUserId.size}")
     private final String providerUserId; // 소셜 제공자 ID
 
-    private final LocalDateTime createdAt; // 생성일시
-    private final LocalDateTime updatedAt; // 수정일시
+    @LastModifiedDate
+    private LocalDateTime createdAt; // 생성일시
+    @LastModifiedDate
+    private LocalDateTime updatedAt; // 수정일시
 
     @NotNull(message = "{user.resumeId.notnull}")
     private final Long resumeId; // 이력서 ID

--- a/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
@@ -8,6 +8,8 @@ import com.umc.tomorrow.domain.member.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -15,6 +17,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "user")
+@EntityListeners(org.springframework.data.jpa.domain.support.AuditingEntityListener.class) // auditing 활성화
 @Getter
 @Setter
 public class User {
@@ -54,9 +57,11 @@ public class User {
     @Column(length = 255, nullable = false)
     private String providerUserId;
 
+    @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/umc/tomorrow/global/common/exception/RestApiException.java
+++ b/src/main/java/com/umc/tomorrow/global/common/exception/RestApiException.java
@@ -4,10 +4,15 @@ import com.umc.tomorrow.global.common.exception.code.BaseCode;
 import com.umc.tomorrow.global.common.exception.code.BaseCodeInterface;
 import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
 public class RestApiException extends RuntimeException {
 
     private final BaseCodeInterface errorCode; //추상화 시킨 인터페이스를 받아서 사용
+
+    // 생성자를 직접 정의하여 부모 클래스(RuntimeException)에 메시지를 전달합니다.
+    public RestApiException(BaseCodeInterface errorCode) {
+        super(errorCode.getCode().getMessage());
+        this.errorCode = errorCode;
+    }
 
     //추상화 시킨 ErrorCode의 getCode()를 사용하여 ErrorCode를 반환
     public BaseCode getErrorCode() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     basename: validation
 
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE}
+    active: ${SPRING_PROFILES_ACTIVE:local}
     
 
   # JPA 설정 
@@ -40,6 +40,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             scope: name, email, gender, mobile
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
           google:
             client-name: google
@@ -47,12 +48,14 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             scope: profile, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
           
           kakao:
             client-name: kakao
             client-id: ${KAKAO_CLIENT_ID}
             authorization-grant-type: authorization_code
             scope: profile_nickname, profile_image
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
         provider:
           naver:


### PR DESCRIPTION
## 관련 이슈
- close #66 

## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- /api/v1/auth/refresh API에서 refreshToken 재발급 시 DB 값도 함께 갱신되도록 구현
- accessToken, refreshToken 테스트용 10초 만료 → 실사용 시간으로 수정 (1시간 / 14일)
- 프론트에서 "토큰 만료 직전 자동 갱신" 구조를 지원할 수 있도록 백엔드 로직 정비
- refreshToken 쿠키 및 헤더에서 유연하게 추출되도록 수정
- 만료된 토큰을 사용할 경우 공통 500 오류가 아닌 AUTH4002 코드로 정확히 반환되도록 개선
- User 엔티티에 @EntityListeners(AuditingEntityListener.class), @LastModifiedDate 추가
- UserDTO 필드에 final 선언되어 JPA가 주입하지 못하던 문제 해결

related to #66

## 리뷰 포인트
- 리뷰어가 확인해주면 좋을 부분이 있다면 작성해 주세요.

## 🖼스크린샷 (선택)
- swagger 캡쳐본입니다. (AuthErrorStatus 3가지에 대해)
<img width="1720" height="640" alt="image" src="https://github.com/user-attachments/assets/f8520448-9355-4007-8463-8196a238831d" />
<img width="722" height="818" alt="image" src="https://github.com/user-attachments/assets/9b002962-9a99-4137-9cac-802f84ac636a" />
<img width="1189" height="769" alt="image" src="https://github.com/user-attachments/assets/9576f49d-d8b1-4d1b-9ab4-680ca3295b0f" />
