### PR TITLE
Fix: 커리어톡 게시글 여부인지 판단 로직 추가

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/controller/CareertalkController.java
@@ -80,15 +80,19 @@ public class CareertalkController {
     /**
      * 커리어톡 게시글 상세 조회(GET)
      * @param careertalkId 조회하고자 하는 커리어톡 게시글 id
+     * @param
      * @return 해당하는 커리어톡 게시글 DTO
      */
     @GetMapping("/{careertalkId}")
     @Operation(summary = "커리어톡 게시글 상세 조회", description = "커리어톡 게시글을 상세 조회합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공")
     public ResponseEntity<BaseResponse<GetCareertalkResponseDto>> getCareertalk(
-            @PathVariable Long careertalkId
+            @PathVariable Long careertalkId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+
     ) {
-        return ResponseEntity.ok(BaseResponse.onSuccess(careertalkQueryService.getCareertalk(careertalkId)));
+        Long userId = customOAuth2User.getUserDTO().getId();
+        return ResponseEntity.ok(BaseResponse.onSuccess(careertalkQueryService.getCareertalk(careertalkId, userId)));
     }
 
     /**

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/dto/response/GetCareertalkResponseDto.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/dto/response/GetCareertalkResponseDto.java
@@ -28,6 +28,9 @@ public class GetCareertalkResponseDto {
     @Schema(description = "내용", example = "요양보호사는 좋은직업입니다.....")
     private String content;
 
+    @Schema(description = "게시글 작성자인지 여부", example = "true")
+    private boolean isAuthor;
+
     @Schema(description = "작성일시", example = "2025-07-08T09:00:00")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryService.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryService.java
@@ -10,7 +10,7 @@ import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkListResponse
 import com.umc.tomorrow.domain.careertalk.dto.response.GetCareertalkResponseDto;
 
 public interface CareertalkQueryService {
-    GetCareertalkResponseDto getCareertalk(Long id);
+    GetCareertalkResponseDto getCareertalk(Long careertalkId, Long userId);
     GetCareertalkListResponseDto getCareertalks(Long cursor, int size);
     GetCareertalkListResponseDto getCareertalksByTitle(String title, Long cursor, int size);
     GetCareertalkListResponseDto getCareertalksByCategory(String category, Long cursor, int size);

--- a/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/careertalk/service/query/CareertalkQueryServiceImpl.java
@@ -70,15 +70,18 @@ public class CareertalkQueryServiceImpl implements CareertalkQueryService {
      */
 
     @Override
-    public GetCareertalkResponseDto getCareertalk(Long careertalkId) {
+    public GetCareertalkResponseDto getCareertalk(Long careertalkId, Long userId) {
         Careertalk careertalk = careertalkRepository.findById(careertalkId)
                 .orElseThrow(() -> new CareertalkException(CareertalkErrorStatus.CAREERTALK_NOT_FOUND));
+
+        boolean isAuthor = careertalk.getUser().getId().equals(userId);
 
         return GetCareertalkResponseDto.builder()
                 .id(careertalk.getId())
                 .category(careertalk.getCategory())
                 .title(careertalk.getTitle())
                 .content(careertalk.getContent())
+                .isAuthor(isAuthor)
                 .createdAt(careertalk.getCreatedAt())
                 .build();
     }


### PR DESCRIPTION
## 관련 이슈
- close #이슈번호

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 커리어톡 게시글 상세 조회시 해당 게시글이 로그인한 유저인지 알기 위한 필드를 반환값으로 추가합니다.

## 리뷰 포인트
- 없습니다.

## 🖼스크린샷 (선택)
<img width="1646" height="1468" alt="image" src="https://github.com/user-attachments/assets/d63fa053-a3ca-49fa-8069-b38cb0bfeb9f" />

