### PR TITLE
Feat: 일자리 상세 조회 페이지 및 일자리 목록 검색 기능

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryController.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryController.java
@@ -2,6 +2,7 @@ package com.umc.tomorrow.domain.job.controller.query;
 
 import com.umc.tomorrow.domain.auth.security.CustomOAuth2User;
 import com.umc.tomorrow.domain.job.dto.request.MyPostResponseDTO;
+import com.umc.tomorrow.domain.job.dto.response.JobDetailResponseDTO;
 import com.umc.tomorrow.domain.job.service.query.JobQueryService;
 import com.umc.tomorrow.global.common.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,13 +11,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/my-posts")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @Tag(name = "MyPosts", description = "내가 작성한 공고 조회 API")
 public class JobQueryController {
@@ -24,7 +26,7 @@ public class JobQueryController {
     private final JobQueryService jobQueryService;
 
     @Operation(summary = "내 모집중 공고 조회", description = "사용자가 작성한 모집중인 공고를 조회합니다.")
-    @GetMapping("/open")
+    @GetMapping("/my-posts/open")
     public ResponseEntity<BaseResponse<List<MyPostResponseDTO>>> getOpenPosts(
             @AuthenticationPrincipal CustomOAuth2User user
     ) {
@@ -33,11 +35,20 @@ public class JobQueryController {
     }
 
     @Operation(summary = "내 모집완료 공고 조회", description = "사용자가 작성한 모집완료된 공고를 조회합니다.")
-    @GetMapping("/closed")
+    @GetMapping("/my-posts/closed")
     public ResponseEntity<BaseResponse<List<MyPostResponseDTO>>> getClosedPosts(
             @AuthenticationPrincipal CustomOAuth2User user
     ) {
         List<MyPostResponseDTO> result = jobQueryService.getMyPosts(user.getUserDTO().getId(), "closed");
         return ResponseEntity.ok(BaseResponse.onSuccess(result));
     }
+
+    @Operation(summary = "일자리 공고 상세페이지 조회", description = "해당하는 jobId의 공고를 상세페이지로 조회합니다.")
+    @GetMapping("/jobs/{jobId}")
+    public ResponseEntity<BaseResponse<JobDetailResponseDTO>> getJobDetail(
+            @PathVariable Long jobId) {
+        JobDetailResponseDTO result = jobQueryService.getJobDetail(jobId);
+        return ResponseEntity.ok(BaseResponse.onSuccess(result));
+    }
+
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/controller/query/JobQueryServiceImpl.java
@@ -7,11 +7,14 @@ package com.umc.tomorrow.domain.job.controller.query;
 
 import com.umc.tomorrow.domain.job.converter.JobConverter;
 import com.umc.tomorrow.domain.job.dto.request.MyPostResponseDTO;
+import com.umc.tomorrow.domain.job.dto.response.JobDetailResponseDTO;
 import com.umc.tomorrow.domain.job.entity.Job;
 import com.umc.tomorrow.domain.job.enums.PostStatus;
 import com.umc.tomorrow.domain.job.exception.JobException;
 import com.umc.tomorrow.domain.job.repository.JobRepository;
 import com.umc.tomorrow.domain.job.service.query.JobQueryService;
+import com.umc.tomorrow.global.common.exception.RestApiException;
+import com.umc.tomorrow.global.common.exception.code.GlobalErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.umc.tomorrow.domain.job.exception.code.JobErrorStatus;
@@ -42,4 +45,13 @@ public class JobQueryServiceImpl implements JobQueryService {
                 .map(jobConverter::toMyPostResponseDto)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public JobDetailResponseDTO getJobDetail(Long jobId) {
+        Job job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new RestApiException(JobErrorStatus.JOB_NOT_FOUND));
+
+        return jobConverter.toJobDetailResponseDTO(job);
+    }
+
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/converter/JobConverter.java
@@ -1,6 +1,7 @@
 package com.umc.tomorrow.domain.job.converter;
 
 import com.umc.tomorrow.domain.job.dto.request.*;
+import com.umc.tomorrow.domain.job.dto.response.JobDetailResponseDTO;
 import com.umc.tomorrow.domain.job.entity.*;
 import org.springframework.stereotype.Component;
 
@@ -92,6 +93,55 @@ public class JobConverter {
                         job.getJobCategory().getDescription()
                         // 추후 WorkEnvironment 등에서 태그 추가 가능
                 ))
+                .build();
+    }
+
+    public JobDetailResponseDTO toJobDetailResponseDTO(Job job) {
+        return JobDetailResponseDTO.builder()
+                .title(job.getTitle())
+                .jobDescription(job.getJobDescription())
+                .workPeriod(job.getWorkPeriod())
+                .isPeriodNegotiable(job.getIsPeriodNegotiable())
+                .workStart(job.getWorkStart())
+                .workEnd(job.getWorkEnd())
+                .isTimeNegotiable(job.getIsTimeNegotiable())
+                .paymentType(job.getPaymentType())
+                .jobCategory(job.getJobCategory())
+                .salary(job.getSalary())
+                .jobImageUrl(job.getJobImageUrl())
+                .companyName(job.getUser().getName())
+                .isActive(job.getIsActive())
+                .recruitmentLimit(job.getRecruitmentLimit())
+                .deadline(job.getDeadline())
+                .preferredQualifications(job.getPreferredQualifications())
+                .location(job.getLocation())
+                .alwaysHiring(job.getAlwaysHiring())
+                .workDays(toWorkDaysRequestDTO(job.getWorkDays()))
+                .workEnvironment(toWorkEnvironmentRequestDTO(job.getWorkEnvironment()))
+                .build();
+    }
+
+    public WorkDaysRequestDTO toWorkDaysRequestDTO(WorkDays workDays) {
+        return WorkDaysRequestDTO.builder()
+                .MON(workDays.getMON())
+                .TUE(workDays.getTUE())
+                .WED(workDays.getWED())
+                .THU(workDays.getTHU())
+                .FRI(workDays.getFRI())
+                .SAT(workDays.getSAT())
+                .SUN(workDays.getSUN())
+                .isDayNegotiable(workDays.getIsDayNegotiable())
+                .build();
+    }
+
+    public WorkEnvironmentRequestDTO toWorkEnvironmentRequestDTO(WorkEnvironment workEnvironment) {
+        return WorkEnvironmentRequestDTO.builder()
+                .canWorkSitting(workEnvironment.isCanWorkSitting())
+                .canWorkStanding(workEnvironment.isCanWorkStanding())
+                .canLiftHeavyObjects(workEnvironment.isCanLiftHeavyObjects())
+                .canLiftLightObjects(workEnvironment.isCanLiftLightObjects())
+                .canMoveActively(workEnvironment.isCanMoveActively())
+                .canCommunicate(workEnvironment.isCanCommunicate())
                 .build();
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/job/dto/response/JobDetailResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/dto/response/JobDetailResponseDTO.java
@@ -1,0 +1,86 @@
+package com.umc.tomorrow.domain.job.dto.response;
+
+import com.umc.tomorrow.domain.job.dto.request.WorkDaysRequestDTO;
+import com.umc.tomorrow.domain.job.dto.request.WorkEnvironmentRequestDTO;
+import com.umc.tomorrow.domain.job.enums.JobCategory;
+import com.umc.tomorrow.domain.job.enums.PaymentType;
+import com.umc.tomorrow.domain.job.enums.WorkPeriod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "일자리 상세 조회 응답 DTO")
+public class JobDetailResponseDTO {
+
+    @Schema(description = "제목", example = "편의점 알바 구인")
+    private String title;
+
+    @Schema(description = "설명", example = "알바 구인합니다.")
+    private String jobDescription;
+
+    @Schema(description = "근무기간",
+            example = "OVER_ONE_YEAR")
+    private WorkPeriod workPeriod;
+
+    @Schema(description = "근무기간 협의", example = "true")
+    private Boolean isPeriodNegotiable = false;
+
+    @Schema(description = "근무 시작 시간", example = "12:00")
+    private LocalTime workStart;
+
+    @Schema(description = "근무 종료 시간", example = "17:00")
+    private LocalTime workEnd;
+
+    @Schema(description = "근무 시작 협의", example = "true")
+    private Boolean isTimeNegotiable = false;
+
+    @Schema(description = "급여 형태", example = "HOURLY")
+    private PaymentType paymentType;
+
+    @Schema(description = "일자리 카테고리", example = "TUTORING")
+    private JobCategory jobCategory;
+
+    @Schema(description = "급여",
+            example = "12000")
+    private Integer salary;
+
+    @Schema(description = "시설 이미지", example = "...")
+    private String jobImageUrl;
+
+    @Schema(description = "회사명", example = "내일")
+    private String companyName;
+
+    @Schema(description = "공고 활성화 여부", example = "true")
+    private Boolean isActive;
+
+    @Schema(description = "모집인원", example = "2")
+    private Integer recruitmentLimit;
+
+    @Schema(description = "공고 마감일", example = "2025-08-01")
+    private LocalDateTime deadline;
+
+    @Schema(description = "우대사항", example = "대학생 우대")
+    private String preferredQualifications;
+
+    @Schema(description = "주소", example = "서울특별시 종로구")
+    private String location;
+
+    @Schema(description = "상시모집 여부", example = "true")
+    private Boolean alwaysHiring = false;
+
+    @Schema(description = "근무요일", example = "[\"mon\"]")
+
+    private WorkDaysRequestDTO workDays;
+
+    @Schema(description = "근무환경", example = "[\"TUTORING\"]")
+    private WorkEnvironmentRequestDTO workEnvironment;
+
+
+}

--- a/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/entity/Job.java
@@ -37,6 +37,9 @@ public class Job extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
+    @Lob
+    private String jobDescription;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private JobCategory jobCategory;
@@ -60,9 +63,6 @@ public class Job extends BaseEntity {
 
     @Column(nullable = false)
     private Integer salary;
-
-    @Lob
-    private String jobDescription;
 
     private String jobImageUrl;
 

--- a/src/main/java/com/umc/tomorrow/domain/job/service/query/JobQueryService.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/service/query/JobQueryService.java
@@ -6,6 +6,7 @@
 package com.umc.tomorrow.domain.job.service.query;
 
 import com.umc.tomorrow.domain.job.dto.request.MyPostResponseDTO;
+import com.umc.tomorrow.domain.job.dto.response.JobDetailResponseDTO;
 
 import java.util.List;
 
@@ -18,4 +19,5 @@ public interface JobQueryService {
      * @return 공고 응답 리스트
      */
     List<MyPostResponseDTO> getMyPosts(Long userId, String status);
+    JobDetailResponseDTO getJobDetail(Long jobId);
 }

--- a/src/main/java/com/umc/tomorrow/domain/searchAndFilter/controller/JobSearchController.java
+++ b/src/main/java/com/umc/tomorrow/domain/searchAndFilter/controller/JobSearchController.java
@@ -4,6 +4,7 @@ import com.umc.tomorrow.domain.searchAndFilter.dto.request.JobSearchRequestDTO;
 import com.umc.tomorrow.domain.searchAndFilter.dto.response.JobSearchResponseDTO;
 import com.umc.tomorrow.domain.searchAndFilter.service.query.JobSearchService;
 import com.umc.tomorrow.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,20 +14,33 @@ import java.util.List;
 
 @Tag(name = "SearchAndFilter", description = "검색 기능 관련 API")
 @RestController
-@RequestMapping("/api/v1/jobs")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class JobSearchController {
 
     private final JobSearchService jobSearchService;
 
     /**
-     * 일자리 정보 세션에 저장(POST)
+     * 일자리 검색(POST)
      * @param requestDTO 검색 조건 DTO
      * @return 성공 응답
      */
-    @PostMapping("/search")
+    @PostMapping("/jobs/search")
     public ResponseEntity<List<JobSearchResponseDTO>> searchJobs(@RequestBody JobSearchRequestDTO requestDTO) {
         List<JobSearchResponseDTO> result = jobSearchService.searchJobs(requestDTO);
         return ResponseEntity.ok(BaseResponse.onSuccess(result).getResult());
     }
+
+    /**
+     * 일자리 목록 조회(GET)
+     * @return 성공 응답
+     */
+    @Operation(summary = "일자리 조회 (GET)", description = "검색 조건을 쿼리스트링으로 받아 일자리를 조회합니다.")
+    @GetMapping("/jobsView")
+    public ResponseEntity<List<JobSearchResponseDTO>> getAllActiveJobs() {
+        List<JobSearchResponseDTO> result = jobSearchService.getAllActiveJobs();
+        return ResponseEntity.ok(BaseResponse.onSuccess(result).getResult());
+    }
+
+
 }

--- a/src/main/java/com/umc/tomorrow/domain/searchAndFilter/repository/JobJpaRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/searchAndFilter/repository/JobJpaRepository.java
@@ -1,0 +1,10 @@
+package com.umc.tomorrow.domain.searchAndFilter.repository;
+
+import com.umc.tomorrow.domain.job.entity.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JobJpaRepository extends JpaRepository<Job, Long> {
+    List<Job> findByIsActiveTrue();
+}

--- a/src/main/java/com/umc/tomorrow/domain/searchAndFilter/repository/JobSearchRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/searchAndFilter/repository/JobSearchRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface JobSearchRepository {
     List<Job> searchJobs(JobSearchRequestDTO dto);
+
 }
 

--- a/src/main/java/com/umc/tomorrow/domain/searchAndFilter/repository/JobSearchRepositoryImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/searchAndFilter/repository/JobSearchRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.umc.tomorrow.domain.searchAndFilter.repository;
 import com.umc.tomorrow.domain.job.entity.Job;
 import com.umc.tomorrow.domain.job.entity.WorkDays;
 import com.umc.tomorrow.domain.searchAndFilter.dto.request.JobSearchRequestDTO;
+import com.umc.tomorrow.domain.searchAndFilter.dto.response.JobSearchResponseDTO;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
@@ -97,4 +98,5 @@ public class JobSearchRepositoryImpl implements JobSearchRepository {
 
         return result;
     }
+
 }

--- a/src/main/java/com/umc/tomorrow/domain/searchAndFilter/service/query/JobSearchService.java
+++ b/src/main/java/com/umc/tomorrow/domain/searchAndFilter/service/query/JobSearchService.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface JobSearchService {
     List<JobSearchResponseDTO> searchJobs(JobSearchRequestDTO requestDTO);
+    List<JobSearchResponseDTO> getAllActiveJobs();
 }

--- a/src/main/java/com/umc/tomorrow/domain/searchAndFilter/service/query/JobSearchServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/searchAndFilter/service/query/JobSearchServiceImpl.java
@@ -1,9 +1,11 @@
 package com.umc.tomorrow.domain.searchAndFilter.service.query;
 
 import com.umc.tomorrow.domain.job.entity.Job;
+import com.umc.tomorrow.domain.job.repository.JobRepository;
 import com.umc.tomorrow.domain.searchAndFilter.converter.JobSearchConverter;
 import com.umc.tomorrow.domain.searchAndFilter.dto.request.JobSearchRequestDTO;
 import com.umc.tomorrow.domain.searchAndFilter.dto.response.JobSearchResponseDTO;
+import com.umc.tomorrow.domain.searchAndFilter.repository.JobJpaRepository;
 import com.umc.tomorrow.domain.searchAndFilter.repository.JobSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class JobSearchServiceImpl implements JobSearchService {
 
+    private final JobJpaRepository jobJpaRepository;
     // 일자리 검색 쿼리를 처리하는 Repository
     private final JobSearchRepository jobSearchRepository;
 
@@ -36,6 +39,18 @@ public class JobSearchServiceImpl implements JobSearchService {
         List<Job> jobs = jobSearchRepository.searchJobs(requestDTO);
 
         // Job → JobSearchResponseDTO 변환 후 리스트로 반환
+        return jobs.stream()
+                .map(converter::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 검색 조건을 기반으로 일자리 목록을 조회하고 DTO로 변환하여 반환
+     * @return 조건에 맞는 일자리 목록의 응답 DTO 리스트
+     */
+    @Override
+    public List<JobSearchResponseDTO> getAllActiveJobs() {
+        List<Job> jobs = jobJpaRepository.findByIsActiveTrue(); // 필터 없는 전체 조회
         return jobs.stream()
                 .map(converter::toResponseDTO)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 관련 이슈
- close #이슈번호

## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 일자리 공고의 상세조회 페이지를 구현하였고, 활성화 상태인 모든 공고를 보여주는 목록 기능을 구현하였습니다.

## 리뷰 포인트
- 리뷰어가 확인해주면 좋을 부분이 있다면 작성해 주세요.

## 🖼스크린샷 (선택)
<img width="1506" height="1044" alt="일자리 상세 조회 페이지" src="https://github.com/user-attachments/assets/0c7e182d-4e02-4b9b-8cce-a548d6495a92" />
<img width="1266" height="304" alt="상세페이지 없는 공고" src="https://github.com/user-attachments/assets/98fe5d3f-010d-43e2-9959-eb7c5cd16d58" />
<img width="1758" height="1040" alt="일자리 목록조회" src="https://github.com/user-attachments/assets/e716f2e6-0785-4fee-b205-55effe16f1db" />

