### PR TITLE
이력서, 자격증 부분 fix

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/converter/ApplicationConverter.java
@@ -13,6 +13,7 @@ import com.umc.tomorrow.domain.application.dto.response.ApplicationDetailsRespon
 import com.umc.tomorrow.domain.application.dto.response.UpdateApplicationStatusResponseDTO;
 import com.umc.tomorrow.domain.application.entity.Application;
 import com.umc.tomorrow.domain.application.enums.ApplicationStatus;
+import com.umc.tomorrow.domain.career.entity.Career;
 import com.umc.tomorrow.domain.member.entity.User;
 import com.umc.tomorrow.domain.certificate.entity.Certificate;
 import com.umc.tomorrow.domain.resume.entity.Experience;
@@ -80,19 +81,31 @@ public class ApplicationConverter {
             List<ApplicationDetailsResponseDTO.ExperienceDTO> experienceDTOS = Optional.ofNullable(resume.getExperiences())
                     .orElse(Collections.emptyList())
                     .stream()
-                    .map(ApplicationConverter::toExperienceDTO)
+                    .map(experience -> ApplicationConverter.toExperienceDTO(experience))
+                    .collect(Collectors.toList());
+
+            List<ApplicationDetailsResponseDTO.CareerDTO> careerDTOS = Optional.ofNullable(resume.getCareer())
+                    .orElse(Collections.emptyList())
+                    .stream()
+                    .map(career -> ApplicationConverter.toCareerDTO(career))
                     .collect(Collectors.toList());
 
             List<ApplicationDetailsResponseDTO.CertificationDTO> certificationDTOS = Optional.ofNullable(resume.getCertificates())
                     .orElse(Collections.emptyList())
                     .stream()
-                    .map(ApplicationConverter::toCertificationDTO)
+                    .map(certificate -> ApplicationConverter.toCertificationDTO(certificate))
                     .collect(Collectors.toList());
 
+            // Introduction이 null인 경우 빈 문자열로 처리
+            String resumeContent = null;
+            if (resume.getIntroduction() != null) {
+                resumeContent = resume.getIntroduction().getContent();
+            }
+
             resumeInfo = ApplicationDetailsResponseDTO.ResumeInfoDTO.builder()
-                    //.resumeContent(resume.getIntroduction())// Resume 엔티티의 introduction 필드사용
-                    .resumeContent(resume.getIntroduction().getContent())
+                    .resumeContent(resumeContent)
                     .experiences(experienceDTOS)
+                    .careers(careerDTOS)
                     .certifications(certificationDTOS)
                     .build();
         }
@@ -123,6 +136,20 @@ public class ApplicationConverter {
     // Certificate 엔티티를 CertificationDTO로 변환
     private static ApplicationDetailsResponseDTO.CertificationDTO toCertificationDTO(Certificate certificate) {
         return ApplicationDetailsResponseDTO.CertificationDTO.builder()
+                .certificationName(certificate.getName())
+                .fileUrl(certificate.getFileUrl())
+                .filename(certificate.getName())
+                .build();
+    }
+
+    // Career 엔티티를 CareerDTO로 변환
+    private static ApplicationDetailsResponseDTO.CareerDTO toCareerDTO(com.umc.tomorrow.domain.career.entity.Career career) {
+        return ApplicationDetailsResponseDTO.CareerDTO.builder()
+                .id(career.getId())
+                .company(career.getCompany())
+                .position(career.getWorkedPeriod().getLabel()) // WorkPeriodType의 라벨 사용
+                .duration(career.getWorkedYear() + "년") // workedYear를 문자열로 변환
+                .description(career.getDescription())
                 .build();
     }
 

--- a/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicationDetailsResponseDTO.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/dto/response/ApplicationDetailsResponseDTO.java
@@ -44,6 +44,7 @@ public class ApplicationDetailsResponseDTO {
         private String resumeContent;
         private String portfolioUrl;
         private List<ExperienceDTO> experiences;
+        private List<CareerDTO> careers;
         private List<CertificationDTO> certifications;
     }
 
@@ -60,6 +61,19 @@ public class ApplicationDetailsResponseDTO {
         private String description; // 상세 설명
     }
 
+    // 경력
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CareerDTO {
+        private Long id;
+        private String company;     // 일한 곳
+        private String position;    // 했던 일
+        private String duration;    // "1년~2년" 등 라벨값
+        private String description; // 상세 설명
+    }
+
     // 자격증
     @Getter
     @Builder
@@ -68,5 +82,6 @@ public class ApplicationDetailsResponseDTO {
     public static class CertificationDTO {
         private String certificationName;
         private String fileUrl;
+        private String filename;
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/application/entity/Application.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/entity/Application.java
@@ -65,7 +65,4 @@ public class Application extends BaseEntity {
         this.setUpdatedAt(LocalDateTime.now());
     }
 
-    protected void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
 } 

--- a/src/main/java/com/umc/tomorrow/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/repository/ApplicationRepository.java
@@ -37,6 +37,14 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     Optional<Application> findByJobIdAndUserId(@Param("jobId") Long jobId, @Param("userId") Long userId);
     
     /**
+     * 특정 공고에 특정 사용자가 지원했는지 확인 (Resume 포함)
+     */
+    @Query("SELECT a FROM Application a " +
+           "LEFT JOIN FETCH a.resume " +
+           "WHERE a.job.id = :jobId AND a.user.id = :userId")
+    Optional<Application> findByJobIdAndUserIdWithResume(@Param("jobId") Long jobId, @Param("userId") Long userId);
+    
+    /**
      * 특정 공고의 특정 상태 지원서 목록 조회
      */
     @Query("SELECT a FROM Application a WHERE a.job.id = :jobId AND a.status = :status")

--- a/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationCommandService.java
+++ b/src/main/java/com/umc/tomorrow/domain/application/service/command/ApplicationCommandService.java
@@ -143,17 +143,19 @@ public class ApplicationCommandService {
      * 개별 지원자 이력서 조회
      */
     public ApplicationDetailsResponseDTO getApplicantResume(Long postId, Long applicantId) {
-        // 1. 공고 ID와 지원자 ID로 지원서(Application)를 조회
-        Application application = applicationRepository.findByJobIdAndUserId(postId, applicantId)
+        Application application = applicationRepository.findByJobIdAndUserIdWithResume(postId, applicantId)
                 .orElseThrow(() -> new RestApiException(ApplicationErrorStatus.APPLICATION_NOT_FOUND));
-
-        // 2. 연관된 엔티티들 조회
         User user = application.getUser();
-
-        // Application 엔티티에 추가된 `resume` 필드를 사용하여 조회
-        Resume resume = application.getResume();
-
-        // 3. Converter를 사용하여 엔티티를 DTO로 변환
+        // Resume 기본 정보만 가져오기 (Introduction은 별도 로드)
+        Resume resume = resumeRepository.findFirstByUserIdOrderByCreatedAtDesc(user.getId())
+                .orElse(null);
+        
+        // Resume이 있고 Introduction이 없다면 Introduction 로드
+        if (resume != null && resume.getIntroduction() == null) {
+            // Introduction을 별도로 로드하는 로직이 필요할 수 있음
+            // 현재는 기본 Resume 정보만 사용
+        }
+        
         return ApplicationConverter.toApplicantResumeResponseDTO(
                 application,
                 user,

--- a/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
+++ b/src/main/java/com/umc/tomorrow/domain/auth/security/CustomSuccessHandler.java
@@ -106,12 +106,12 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         }
 
 
-        // 쿠키 직접 문자열로 세팅 (SameSite=None, Secure=true)
-        String accessCookie = String.format("Authorization=%s; Max-Age=%d; Path=/; HttpOnly; Secure; SameSite=None",
+        // 쿠키 직접 문자열로 세팅 (로컬 테스트용 - Secure=false)
+        String accessCookie = String.format("Authorization=%s; Max-Age=%d; Path=/; HttpOnly; Secure=false; SameSite=None",
                 accessToken, (int) accessTokenExpiredSeconds);
         response.addHeader("Set-Cookie", accessCookie);
 
-        String refreshCookie = String.format("RefreshToken=%s; Max-Age=%d; Path=/; HttpOnly; Secure; SameSite=None",
+        String refreshCookie = String.format("RefreshToken=%s; Max-Age=%d; Path=/; HttpOnly; Secure=false; SameSite=None",
                 refreshToken, (int) refreshTokenExpiredSeconds);
         response.addHeader("Set-Cookie", refreshCookie);
 
@@ -120,7 +120,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.addHeader("RefreshToken", refreshToken);
 
          // 프론트로 리다이렉트
-        // response.sendRedirect("http://localhost:5173/onboarding");
+        response.sendRedirect("http://localhost:5173/onboarding");
 
 
 //        response.addCookie(createCookie("Authorization", accessToken, (int)accessTokenExpiredSeconds));

--- a/src/main/java/com/umc/tomorrow/domain/certificate/dto/response/CertificateResponse.java
+++ b/src/main/java/com/umc/tomorrow/domain/certificate/dto/response/CertificateResponse.java
@@ -20,4 +20,7 @@ public class CertificateResponse {
     @Schema(description = "자격증 파일 주소", example = "https://chatgpt.com/c/6886e83b-7298-8321-a5d0-26ed42114e4a")
     private String fileUrl;
 
+    @Schema(description = "자격증 파일명", example = "Group46.png")
+    private String filename;
+
 }

--- a/src/main/java/com/umc/tomorrow/domain/certificate/entity/Certificate.java
+++ b/src/main/java/com/umc/tomorrow/domain/certificate/entity/Certificate.java
@@ -17,6 +17,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -33,12 +34,6 @@ public class Certificate extends BaseEntity {
     private String fileUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id")
     private Resume resume;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 } 

--- a/src/main/java/com/umc/tomorrow/domain/certificate/service/command/CertificateCommandServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/certificate/service/command/CertificateCommandServiceImpl.java
@@ -43,8 +43,10 @@ public class CertificateCommandServiceImpl implements CertificateCommandService 
         }
 
         String fileUrl = s3Uploader.upload(file, "certificates");
+        String filename = file.getOriginalFilename();
 
         Certificate certificate = Certificate.builder()
+                .name(filename)
                 .fileUrl(fileUrl)
                 .resume(resume)
                 .build();
@@ -54,6 +56,7 @@ public class CertificateCommandServiceImpl implements CertificateCommandService 
         return CertificateResponse.builder()
                 .id(saved.getId())
                 .fileUrl(saved.getFileUrl())
+                .filename(saved.getName())
                 .build();
     }
 
@@ -75,6 +78,7 @@ public class CertificateCommandServiceImpl implements CertificateCommandService 
         return CertificateResponse.builder()
                 .id(certificate.getId())
                 .fileUrl(certificate.getFileUrl())
+                .filename(certificate.getName())
                 .build();
     }
 }

--- a/src/main/java/com/umc/tomorrow/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/controller/MemberController.java
@@ -37,6 +37,10 @@ public class MemberController {
         if (user == null) {
             return ResponseEntity.status(401).build();
         }
+        
+        // resumeId가 null인 경우 업데이트
+        memberService.updateResumeIdIfNull(user.getUserDTO().getId());
+        
         UserDTO userDTO = user.getUserDTO();
         return ResponseEntity.ok(userDTO);
     }

--- a/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
+++ b/src/main/java/com/umc/tomorrow/domain/member/entity/User.java
@@ -7,6 +7,7 @@ import com.umc.tomorrow.domain.member.enums.Gender;
 import com.umc.tomorrow.domain.member.enums.Provider;
 import com.umc.tomorrow.domain.member.enums.UserStatus;
 import com.umc.tomorrow.domain.preferences.entity.Preference;
+import com.umc.tomorrow.domain.resume.entity.Resume;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -88,5 +89,7 @@ public class User {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Preference preference;
+
+    // Resume 관계 매핑 제거 (resumeId 필드만 사용)
 
 }

--- a/src/main/java/com/umc/tomorrow/domain/resume/entity/Experience.java
+++ b/src/main/java/com/umc/tomorrow/domain/resume/entity/Experience.java
@@ -12,6 +12,7 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/umc/tomorrow/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/resume/repository/ResumeRepository.java
@@ -9,11 +9,23 @@ package com.umc.tomorrow.domain.resume.repository;
 import com.umc.tomorrow.domain.resume.entity.Resume;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
     Optional<Resume> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
     Optional<Resume> findByIdAndUserId(Long resumeId, Long userId);
+    
+    // MultipleBagFetchException 발생으로 인해 주석 처리
+    // @Query("SELECT r FROM Resume r " +
+    //        "LEFT JOIN FETCH r.introduction " +
+    //        "LEFT JOIN FETCH r.career " +
+    //        "LEFT JOIN FETCH r.certificates " +
+    //        "LEFT JOIN FETCH r.experiences " +
+    //        "WHERE r.user.id = :userId " +
+    //        "ORDER BY r.createdAt DESC")
+    // Optional<Resume> findFirstByUserIdWithAllRelationsOrderByCreatedAtDesc(@Param("userId") Long userId);
 }
 

--- a/src/main/java/com/umc/tomorrow/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/umc/tomorrow/domain/resume/service/ResumeService.java
@@ -40,6 +40,12 @@ public class ResumeService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new MemberException(MemberStatus.MEMBER_NOT_FOUND));
         Resume resume = ResumeConverter.toEntity(dto, user);
-        return resumeRepository.save(resume);
+        Resume savedResume = resumeRepository.save(resume);
+        
+        // 사용자의 resumeId 필드 업데이트
+        user.setResumeId(savedResume.getId());
+        userRepository.save(user);
+        
+        return savedResume;
     }
 } 

--- a/src/main/java/com/umc/tomorrow/global/common/base/BaseEntity.java
+++ b/src/main/java/com/umc/tomorrow/global/common/base/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,6 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 public class BaseEntity {
 
     @CreatedDate
@@ -20,5 +22,5 @@ public class BaseEntity {
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
-    protected LocalDateTime updatedAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,7 +16,7 @@ spring:
   # JPA 설정 (로컬 개발용)
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 관련 이슈
- close #150 

## PR 유형

- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정


## 작업 내용
1. …rtificationDTO에 filename 필드 추가
2. resumeId null 문제 해결: User 엔티티에 @OneToOne 관계 추가
UserConverter에서 resumeId를 Resume 엔티티에서 가져오도록 수정
ResumeService에서 이력서 저장 후 resumeId 업데이트
MemberService에 updateResumeIdIfNull 메서드 추가
MemberController에서 사용자 정보 조회 시 resumeId 업데이트 호출
3. career 필드 추가: ApplicationDetailsResponseDTO.ResumeInfoDTO에 careers 리스트 추가
4. 자격증 null 문제 해결: Certificate 엔티티에 @JoinColumn 추가 

## 리뷰 포인트
- 리뷰어가 확인해주면 좋을 부분이 있다면 작성해 주세요.

## 🖼스크린샷 (선택)
<img width="719" height="310" alt="image" src="https://github.com/user-attachments/assets/3067d27d-6f96-4b18-a646-2086287547f2" />
<img width="958" height="587" alt="image" src="https://github.com/user-attachments/assets/c562f2f4-86c6-44d4-a7ef-20ce89875919" />
