### PR TITLE
Feat: docker-compose.yml에 ngrinder 설정 추가

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,5 +47,33 @@ services:
       timeout: 5s
       retries: 5
 
+  ngrinder-controller:
+    image: ngrinder/controller:3.5.9
+    container_name: ngrinder-controller
+    profiles: [ "perf" ]
+    ports:
+      - "8081:80"
+      - "16001:16001"
+      - "12000-12004:12000-12004"
+    volumes:
+      - ngrinder-controller-data:/opt/ngrinder-controller
+    restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+
+  ngrinder-agent:
+    image: ngrinder/agent:latest
+    container_name: ngrinder-agent
+    profiles: [ "perf" ]
+    command: [ "ngrinder-controller:80" ]
+    restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 131072
+        hard: 131072
+
 volumes:
   tomorrow-local-data:
+  ngrinder-controller-data:


### PR DESCRIPTION
## 관련 이슈
- close #154

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 환경 설정

## 작업 내용
- ngrinder 설정을 추가합니다.

## 리뷰 포인트
- 이 설정 추가 후에 ngrinder가 서버에 부하를 많이 주어서 perf 옵션을 통해서만 터미널에서 수동으로 실행할 수 있게 설정했습니다. 이후에 ngrinder 사용 방법 및 관련 레퍼런스는 회의 때 공유드리겠습니다.

## 🖼스크린샷 (선택)
- db나 ui, swagger 등의 캡쳐본을 첨부해 주세요.
