### PR TITLE
Fix : 이력서 get api 경력 목록으로 변경

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/career/controller/CareerCommandController.java
+++ b/src/main/java/com/umc/tomorrow/domain/career/controller/CareerCommandController.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Career", description = "경력 관련 API")
 @RestController
 @RequestMapping("/api/v1/resumes/{resumeId}/experiences")
@@ -70,22 +72,20 @@ public class CareerCommandController {
     }
 
     /**
-     * 이력서 경력 조회(GET)
+     * 이력서 경력 목록 조회(GET)
      * @param resumeId 이력서 아이디
-     * @param careerId 경력 아이디
      * @param user 인증된 사용자
      * @return 성공 응답
      */
-    @GetMapping("/{careerId}")
-    @Operation(summary = "이력서 경력 조회", description = "경력 정보를 조회하는 API입니다.")
-    public ResponseEntity<BaseResponse<CareerGetResponseDTO>> getCareer(
+    @GetMapping
+    @Operation(summary = "이력서 경력 목록 조회", description = "경력 목록을 조회하는 API입니다.")
+    public ResponseEntity<BaseResponse<List<CareerGetResponseDTO>>> getCareerList(
             @PathVariable Long resumeId,
-            @PathVariable Long careerId,
             @AuthenticationPrincipal CustomOAuth2User user) {
 
         Long userId = user.getUserDTO().getId();
 
-        CareerGetResponseDTO response = careerQueryService.getCareer(userId, resumeId, careerId);
+        List<CareerGetResponseDTO> response = careerQueryService.getCareerList(userId, resumeId);
 
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }

--- a/src/main/java/com/umc/tomorrow/domain/career/repository/CareerRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/career/repository/CareerRepository.java
@@ -2,6 +2,8 @@ package com.umc.tomorrow.domain.career.repository;
 
 import com.umc.tomorrow.domain.career.entity.Career;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface CareerRepository  extends JpaRepository<Career, Long> {
+    List<Career> findByResumeId(Long resumeId);
 }

--- a/src/main/java/com/umc/tomorrow/domain/career/service/query/CareerQueryService.java
+++ b/src/main/java/com/umc/tomorrow/domain/career/service/query/CareerQueryService.java
@@ -1,7 +1,9 @@
 package com.umc.tomorrow.domain.career.service.query;
 
 import com.umc.tomorrow.domain.career.dto.response.CareerGetResponseDTO;
+import java.util.List;
 
 public interface CareerQueryService {
     CareerGetResponseDTO getCareer(Long userId, Long resumeId, Long careerId);
+    List<CareerGetResponseDTO> getCareerList(Long userId, Long resumeId);
 }

--- a/src/main/java/com/umc/tomorrow/domain/career/service/query/CareerQueryServiceImpl.java
+++ b/src/main/java/com/umc/tomorrow/domain/career/service/query/CareerQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.tomorrow.domain.career.service.query;
 import com.umc.tomorrow.domain.career.converter.CareerConverter;
 import com.umc.tomorrow.domain.career.dto.response.CareerGetResponseDTO;
 import com.umc.tomorrow.domain.career.entity.Career;
+import java.util.List;
 import com.umc.tomorrow.domain.career.exception.code.CareerStatus;
 import com.umc.tomorrow.domain.career.repository.CareerRepository;
 import com.umc.tomorrow.domain.member.entity.User;
@@ -52,5 +53,30 @@ public class CareerQueryServiceImpl implements CareerQueryService {
         }
 
         return CareerConverter.toGetResponseDTO(career);
+    }
+
+    /**
+     * 이력서 경력 목록 조회 메서드
+     * @param userId 경력을 조회하는 사용자
+     * @param resumeId 조회할 이력서 id
+     * @return converter로 이동
+     */
+    @Override
+    public List<CareerGetResponseDTO> getCareerList(Long userId, Long resumeId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(CareerStatus.CAREER_FORBIDDEN));
+
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new RestApiException(CareerStatus.CAREER_NOT_FOUND));
+
+        if (!resume.getUser().getId().equals(user.getId())) {
+            throw new RestApiException(CareerStatus.CAREER_FORBIDDEN);
+        }
+
+        List<Career> careers = careerRepository.findByResumeId(resumeId);
+        
+        return careers.stream()
+                .map(CareerConverter::toGetResponseDTO)
+                .collect(java.util.stream.Collectors.toList());
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #164 

## PR 유형
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링


## 작업 내용
- 이력서 get api - 단일 경력 조회에서 전체 목록 조회하도록 수정

## 리뷰 포인트
- 리뷰어가 확인해주면 좋을 부분이 있다면 작성해 주세요.

## 🖼스크린샷 (선택)
- db나 ui, swagger 등의 캡쳐본을 첨부해 주세요.
