### PR TITLE
Fix: 내일 추천 조건 수정에 따른 로직 변경(jpql이용)

### DIFF
--- a/src/main/java/com/umc/tomorrow/domain/job/repository/JobRecommendationJpaRepository.java
+++ b/src/main/java/com/umc/tomorrow/domain/job/repository/JobRecommendationJpaRepository.java
@@ -1,0 +1,97 @@
+package com.umc.tomorrow.domain.job.repository;
+
+import com.umc.tomorrow.domain.job.entity.Job;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JobRecommendationJpaRepository {
+
+    private final EntityManager em;
+
+    public List<JobWithScore> findRecommendedByUser(
+            Long userId,
+            boolean hasHuman,
+            boolean hasDelivery,
+            boolean hasPhysical,
+            boolean hasSit,
+            boolean hasStand,
+            Integer cursorScore, // 첫 페이지면 null
+            Long cursorId,       // 첫 페이지면 null
+            int size
+    ) {
+        // 점수: 유저가 true로 고른 항목에 한해, env가 true면 +1
+        final String scoreExpr =
+                "(CASE WHEN :hasHuman    = true AND we.canCommunicate   = true THEN 1 ELSE 0 END)"
+                        + "+(CASE WHEN :hasDelivery = true AND we.canCarryObjects  = true THEN 1 ELSE 0 END)"
+                        + "+(CASE WHEN :hasPhysical = true AND we.canMoveActively  = true THEN 1 ELSE 0 END)"
+                        + "+(CASE WHEN :hasSit      = true AND we.canWorkSitting   = true THEN 1 ELSE 0 END)"
+                        + "+(CASE WHEN :hasStand    = true AND we.canWorkStanding  = true THEN 1 ELSE 0 END)";
+
+        // 네거티브: 유저가 false로 고른 항목은 env가 반드시 false
+        // → (env=false) OR (그 항목을 유저가 선택함)
+        final String negatives =
+                "("
+                        + " (we.canCommunicate   = false OR :hasHuman    = true) AND"
+                        + " (we.canCarryObjects  = false OR :hasDelivery = true) AND"
+                        + " (we.canMoveActively  = false OR :hasPhysical = true) AND"
+                        + " (we.canWorkSitting   = false OR :hasSit      = true) AND"
+                        + " (we.canWorkStanding  = false OR :hasStand    = true)"
+                        + ")";
+
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("SELECT j, ").append(scoreExpr).append(" AS score ")
+                .append("FROM Job j ")
+                .append("JOIN j.workEnvironment we ")
+                .append("WHERE ").append(negatives)          // 1) 원치 않는 조건 제거
+                .append(" AND (").append(scoreExpr).append(" >= 1) "); // 2) true 중 1개 이상 만족
+
+        // 3) 키셋 페이징 (score DESC, id DESC)
+        if (cursorScore != null && cursorId != null) {
+            jpql.append(" AND (")
+                    .append(scoreExpr).append(" < :cursorScore ")
+                    .append("OR (").append(scoreExpr).append(" = :cursorScore AND j.id < :cursorId)) ");
+        }
+
+        jpql.append(" ORDER BY ").append(scoreExpr).append(" DESC, j.id DESC");
+
+        Query q = em.createQuery(jpql.toString());
+        q.setParameter("hasHuman",    hasHuman);
+        q.setParameter("hasDelivery", hasDelivery);
+        q.setParameter("hasPhysical", hasPhysical);
+        q.setParameter("hasSit",      hasSit);
+        q.setParameter("hasStand",    hasStand);
+
+        if (cursorScore != null && cursorId != null) {
+            q.setParameter("cursorScore", cursorScore);
+            q.setParameter("cursorId", cursorId);
+        }
+        q.setMaxResults(size);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = q.getResultList();
+
+        List<JobWithScore> result = new ArrayList<>(rows.size());
+        for (Object[] row : rows) {
+            Job job = (Job) row[0];
+            Integer score = ((Number) row[1]).intValue();
+            result.add(new JobWithScore(job, score));
+        }
+        return result;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class JobWithScore {
+        private final Job job;
+        private final Integer score;
+    }
+}
+


### PR DESCRIPTION
## 관련 이슈
- close #148

## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 유저가 선택한 온보딩을 하나라도 만족하지 않는 job은 조건에서 제외
- 기존에 모든 job을 조회해온 후에 스코어를 계산하는 로직 -> 제외해야하는 조건과 만족해야하는 조건을 쿼리 매개변수로 넘겨서 매핑하여 만족하는 job을 조회하는 로직으로 수정
- swagger를 이용한 테스트

## 리뷰 포인트
- 없습니다.

## 🖼스크린샷 (선택)
<img width="1162" height="874" alt="스크린샷 2025-08-13 오후 3 22 42" src="https://github.com/user-attachments/assets/958e5cc0-b0b1-4b2f-b2c3-07af39832f51" />

<img width="867" height="838" alt="스크린샷 2025-08-13 오후 3 23 00" src="https://github.com/user-attachments/assets/ad070bf8-1d40-4180-830f-3560b760bda1" />
