### PR TITLE
Feat: 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/umc/tomorrow/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/tomorrow/global/config/SecurityConfig.java
@@ -13,7 +13,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -21,7 +20,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity
@@ -93,7 +91,7 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/swagger-ui/index.html",
                                 "/v3/api-docs/**",
-                                "/login"
+                                "/login/**","//oauth2/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );
@@ -102,3 +100,4 @@ public class SecurityConfig {
         return http.build();
     }
 }
+

--- a/src/main/java/com/umc/tomorrow/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/tomorrow/global/config/SecurityConfig.java
@@ -67,14 +67,6 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                // 인증 실패시 401 JSON 응답
-                .exceptionHandling(e -> e
-                        .authenticationEntryPoint((req, res, ex) -> {
-                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            res.setContentType("application/json;charset=UTF-8");
-                            res.getWriter().write("{\"code\":\"AUTH401\",\"message\":\"Unauthorized\"}");
-                        })
-                )
                 .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(endpoint -> endpoint.userService(customOAuth2UserService))

--- a/src/main/java/com/umc/tomorrow/global/config/SessionCookieConfig.java
+++ b/src/main/java/com/umc/tomorrow/global/config/SessionCookieConfig.java
@@ -11,20 +11,37 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SessionCookieConfig {
 
-    // SameSite 설정
+    /**
+     * SameSite 설정
+     * - local: Lax (브라우저에서 Secure=false 허용)
+     * - dev/prod: None (cross-site 요청 허용, Secure=true와 세트)
+     */
     @Bean
     public TomcatServletWebServerFactory cookieSameSiteCustomizer() {
         return new TomcatServletWebServerFactory() {
             @Override
             protected void postProcessContext(org.apache.catalina.Context context) {
+                String activeProfile = System.getProperty("spring.profiles.active", "local");
                 Rfc6265CookieProcessor cookieProcessor = new Rfc6265CookieProcessor();
-                cookieProcessor.setSameSiteCookies("None"); // 운영·로컬 모두 None
+
+                if ("local".equalsIgnoreCase(activeProfile)) {
+                    // 로컬에서는 HTTPS가 아니므로 Lax로 (Secure=false 조합 허용)
+                    cookieProcessor.setSameSiteCookies("Lax");
+                } else {
+                    // 운영/개발 서버는 HTTPS이므로 None + Secure
+                    cookieProcessor.setSameSiteCookies("None");
+                }
+
                 context.setCookieProcessor(cookieProcessor);
             }
         };
     }
 
-    // Secure 플래그 설정
+    /**
+     * Secure 플래그 설정
+     * - local: false
+     * - dev/prod: true
+     */
     @Bean
     public ServletContextInitializer secureFlagCustomizer() {
         return new ServletContextInitializer() {
@@ -32,10 +49,10 @@ public class SessionCookieConfig {
             public void onStartup(ServletContext servletContext) throws ServletException {
                 String activeProfile = System.getProperty("spring.profiles.active", "local");
 
-                if (!"local".equalsIgnoreCase(activeProfile)) {
-                    servletContext.getSessionCookieConfig().setSecure(true);
-                } else {
+                if ("local".equalsIgnoreCase(activeProfile)) {
                     servletContext.getSessionCookieConfig().setSecure(false);
+                } else {
+                    servletContext.getSessionCookieConfig().setSecure(true);
                 }
             }
         };


### PR DESCRIPTION
## 관련 이슈
- close #220

## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 환경 설정

## 작업 내용
- 로그아웃 기능 API 구현
- 여러 환경에서의 필요한 토큰 관련 분기로직 개선
- 스웨거를 이용한 API테스트

## 리뷰 포인트
- 스웨거 이용시에 로그인 후에 나오는 json형태의 엑세스 토큰을 활용하여 스웨거 테스트 진행하면 됩니다.



## 🖼스크린샷 (선택)
* 로그아웃 api 호출 전 리프레시 토큰이 쿠키형태로 저장되어있는 상태
<img width="782" height="640" alt="스크린샷 2025-08-18 오전 3 02 27" src="https://github.com/user-attachments/assets/1e33f5db-36eb-4a48-b383-cf4fafb362c8" />
* 로그아웃이 성공하여 리프레시 토큰이 날라간 형태
<img width="771" height="660" alt="스크린샷 2025-08-18 오전 3 02 41" src="https://github.com/user-attachments/assets/8b3f3e94-77d7-4528-93ca-cd8de8652d96" />

